### PR TITLE
increase build timeout

### DIFF
--- a/src/methods/buildAndUpload.js
+++ b/src/methods/buildAndUpload.js
@@ -11,8 +11,8 @@ async function buildAndUpload({dir, buildDir, ipfsProvider, silent}) {
   // If the provider is infura don't show progress, their API does not support it
   const showProgress = !(ipfsProvider || '').includes('infura');
 
-  // Define build timeout (20 min)
-  const buildTimeout = 20*60*1000;
+  // Define build timeout (30 min)
+  const buildTimeout = 30*60*1000;
 
   // Init IPFS instance
   const ipfs = new Ipfs(ipfsProvider);


### PR DESCRIPTION
For a DAppNodePackage I try, Polkadot build here https://github.com/branciard/DAppNodePackage-polkadot-alexander/blob/master/build/Dockerfile needs 21 mins  :).  so I have to manually edit to 30 min to succeed.