### PR TITLE
Add custom Travis provider

### DIFF
--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -107,7 +107,7 @@ exports.handler = async ({
   if (dappnode_team_preset) {
     if (TRAVIS) {
       ethProvider = "infura";
-      ipfsProvider = "infura";
+      ipfsProvider = "http://ipfs.dappnode.io";
       // Activate verbose to see logs easier afterwards
       verbose = true;
     }


### PR DESCRIPTION
When running `publish`, if the user uses the `--dappnode_team_preset` flag and the CLI is running in Travis (TRAVIS=true), use the custom provider "http://ipfs.dappnode.io"