### PR TITLE
Directory debug

### DIFF
--- a/src/methods/initializeDnp.js
+++ b/src/methods/initializeDnp.js
@@ -93,15 +93,6 @@ It only covers the most common items, and tries to guess sensible defaults.
     description: answers.description,
     avatar: "",
     type: "service",
-    image: {
-      path: "",
-      hash: "",
-      size: "",
-      volumes: [],
-      ports: [],
-      environment: [],
-      restart: "always"
-    },
     dependencies: {},
     author: answers.author,
     categories: ["Developer tools"],
@@ -116,7 +107,14 @@ It only covers the most common items, and tries to guess sensible defaults.
 
   // Write manifest and compose
   writeManifest({ manifest, dir });
-  generateAndWriteCompose({ manifest, dir });
+  generateAndWriteCompose({
+    manifest: {
+      name: manifest.name,
+      version: manifest.version,
+      image: {}
+    },
+    dir
+  });
 
   // Initialize Dockerfile
   fs.writeFileSync(

--- a/src/methods/initializeDnp.js
+++ b/src/methods/initializeDnp.js
@@ -127,7 +127,19 @@ CMD [ "echo", "happy buidl" ]
 `
   );
 
-  console.log(`Initialized DNP ${manifest.name}`);
+  console.log(`
+Your DAppNodePackage is ready: ${manifest.name}
+
+To start, you can:
+
+ - Develop your dockerized app in   ./build
+ - Add settings in the compose at   ./docker-compose.yml
+ - Add metadata in the manifest at  ./dappnode_package.json
+
+Once ready, you can build, install, and test it by running
+
+  dappnodesdk build 
+`);
 }
 
 module.exports = initializeDnp;

--- a/src/tasks/buildAndUpload.js
+++ b/src/tasks/buildAndUpload.js
@@ -56,6 +56,18 @@ function buildAndUpload({
   const manifest = readManifest({ dir });
   const manifestPath = getManifestPath({ dir });
 
+  // Make sure the release is of correct type
+  if (isDirectoryRelease && manifest.image)
+    throw Error(`You are building a directory type release but there are image settings in the manifest.
+Please, move all image settings from the manifest to the docker-compose.yml 
+and remove the manifest.image property
+`);
+  // If there is no manifest.image prop, assume directory type
+  if (!manifest.image && !isDirectoryRelease) {
+    console.warn("Assuming directory type release");
+    isDirectoryRelease = true;
+  }
+
   // Define variables from manifest
   const { name, version } = manifest;
 

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -98,11 +98,11 @@ function generateCompose({ manifest }) {
 
   const service = {};
 
+  service.build = "./build";
+
   // Image name
   service.image = manifest.name + ":" + manifest.version;
-  if (manifest.restart) service.restart = manifest.restart;
-
-  service.build = "./build";
+  service.restart = manifest.image.restart || "always";
 
   // Volumes
   if (manifest.image.volumes) {

--- a/test/tasks/buildAndUpload.test.js
+++ b/test/tasks/buildAndUpload.test.js
@@ -1,6 +1,7 @@
 const expect = require("chai").expect;
 const fs = require("fs");
 const { rmSafe, shellSafe } = require("../shellSafe");
+const { omit } = require("lodash");
 const yaml = require("js-yaml");
 const buildAndUpload = require("../../src/tasks/buildAndUpload");
 
@@ -79,6 +80,12 @@ ENV test=1
   }).timeout(60 * 1000);
 
   it("Should build and upload the current version as directory type release", async () => {
+    // Rewrite the manifest to not contain image
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify(omit(manifest, "image"), null, 2)
+    );
+
     const buildAndUploadTasks = buildAndUpload({
       dir: "./",
       buildDir,


### PR DESCRIPTION
Prevents annoying errors where a manifest type release happens when you wanted to release a directory type release. Now the SDK will guess the type from the existence of `manifest.image`

Also on init the template is in directory type release, and present a better message as "next steps" for the user

```
lion$ dappnodesdk init -y -f

Your DAppNodePackage is ready: dappnodesdk.public.dappnode.eth

To start, you can:

 - Develop your dockerized app in   ./build
 - Add settings in the compose at   ./docker-compose.yml
 - Add metadata in the manifest at  ./dappnode_package.json

Once ready, you can build, install, and test it by running

  dappnodesdk build
```