### PR TITLE
Parse upstream version(s) from compose build args

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -5,6 +5,8 @@ export class YargsError extends Error {}
 
 export const publishTxAppUrl = "https://dappnode.github.io/sdk-publish/";
 
+export const UPSTREAM_VERSION_VARNAME = "UPSTREAM_VERSION";
+
 /**
  * Plain text file with should contain the IPFS hash of the release
  * Necessary for the installer script to fetch the latest content hash

--- a/src/tasks/buildAndUpload.ts
+++ b/src/tasks/buildAndUpload.ts
@@ -14,7 +14,12 @@ import {
 } from "../params";
 import { ipfsAddFromFs } from "../utils/ipfs/ipfsAddFromFs";
 import { swarmAddDirFromFs } from "../utils/swarmAddDirFromFs";
-import { prepareComposeForBuild, getComposePath } from "../utils/compose";
+import {
+  prepareComposeForBuild,
+  getComposePath,
+  readCompose,
+  parseComposeUpstreamVersion
+} from "../utils/compose";
 import { ListrContextBuildAndPublish } from "../types";
 import { parseTimeout } from "../utils/timeout";
 import { buildWithBuildx } from "./buildWithBuildx";
@@ -64,11 +69,6 @@ and not declared in the manifest. Please add your package avatar to this directo
 as ${releaseFiles.avatar.defaultName} and then remove the 'manifest.avatar' property.
 `);
 
-  // Bump upstreamVersion if provided
-  if (process.env.UPSTREAM_VERSION) {
-    manifest.upstreamVersion = process.env.UPSTREAM_VERSION;
-  }
-
   // Define variables from manifest
   const { name, version } = manifest;
   if (/[A-Z]/.test(name))
@@ -95,6 +95,12 @@ as ${releaseFiles.avatar.defaultName} and then remove the 'manifest.avatar' prop
   const composeRootPath = getAssetPathRequired(releaseFiles.compose, dir);
   const avatarRootPath = getAssetPathRequired(releaseFiles.avatar, dir);
   if (avatarRootPath) verifyAvatar(avatarRootPath);
+
+  // Bump upstreamVersion if provided
+  const upstreamVersion =
+    parseComposeUpstreamVersion(readCompose(dir)) ||
+    process.env.UPSTREAM_VERSION;
+  if (upstreamVersion) manifest.upstreamVersion;
 
   return [
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,13 @@ export interface ComposeVolumes {
 }
 
 export interface ComposeService {
-  build?: string;
+  build?:
+    | string
+    | {
+        context?: string; // ./dir
+        dockerfile?: string; // Dockerfile-alternate
+        args?: { [varName: string]: string }; // { buildno: 1}
+      };
   container_name?: string; // "DAppNodeCore-dappmanager.dnp.dappnode.eth";
   image: string; // "dappmanager.dnp.dappnode.eth:0.2.6";
   volumes?: string[]; // ["dappmanagerdnpdappnodeeth_data:/usr/src/app/dnp_repo/"];

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,5 @@
+export function toTitleCase(str: string): string {
+  return str.replace(/\w\S*/g, function (txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
+}

--- a/test/utils/compose.test.ts
+++ b/test/utils/compose.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
-import fs from "fs";
 import { Compose } from "../../src/types";
 import { testDir, cleanTestDir } from "../testUtils";
 import {
   readCompose,
   writeCompose,
-  prepareComposeForBuild
+  prepareComposeForBuild,
+  parseComposeUpstreamVersion
 } from "../../src/utils/compose";
 
 describe("util > compose", () => {
@@ -80,6 +80,31 @@ describe("util > compose", () => {
 
       expect(imageTags).to.deep.equal(expectedImageTags);
       expect(readCompose(testDir)).to.deep.equal(expectedCompose);
+    });
+  });
+
+  describe("parseComposeUpstreamVersion", () => {
+    it("Should parse multiple upstream versions", () => {
+      const compose: Compose = {
+        version: "3.4",
+        services: {
+          validator: {
+            image: "sample-image",
+            build: {
+              args: {
+                UPSTREAM_VERSION_PRYSM: "v1.0.0-alpha.25",
+                UPSTREAM_VERSION_LIGHTHOUSE: "v0.2.9"
+              }
+            }
+          }
+        }
+      };
+
+      const upstreamVersion = parseComposeUpstreamVersion(compose);
+
+      expect(upstreamVersion).to.equal(
+        "Prysm: v1.0.0-alpha.25, Lighthouse: v0.2.9"
+      );
     });
   });
 });


### PR DESCRIPTION
Turns a compose like this one
```yaml
version: '3.4'
services:
  validator:
    image: sample-image
    build:
      args:
        UPSTREAM_VERSION_PRYSM: v1.0.0-alpha.25
        UPSTREAM_VERSION_LIGHTHOUSE: v0.2.9
```
to a manifest with
```json
{
  "upstreamVersion": "Prysm: v1.0.0-alpha.25, Lighthouse: v0.2.9"
}
```