### PR TITLE
feat: cmdline argument "--compose_file_name"

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -74,6 +74,7 @@ export async function buildHandler({
   skip_upload,
   // Global options
   dir,
+  compose_file_name,
   silent,
   verbose
 }: CliCommandOptions): Promise<{ releaseMultiHash: string }> {
@@ -83,6 +84,7 @@ export async function buildHandler({
   const userTimeout = timeout;
   const skipSave = skip_save;
   const skipUpload = skip_save || skip_upload;
+  const composeFileName = compose_file_name;
   const nextVersion = getCurrentLocalVersion({ dir });
   const buildDir = path.join(dir, `build_${nextVersion}`);
 
@@ -94,7 +96,8 @@ export async function buildHandler({
       uploadTo,
       userTimeout,
       skipSave,
-      skipUpload
+      skipUpload,
+      composeFileName
     }),
     { renderer: verbose ? "verbose" : silent ? "silent" : "default" }
   );

--- a/src/commands/increase.ts
+++ b/src/commands/increase.ts
@@ -35,7 +35,12 @@ export const increase: CommandModule<CliGlobalOptions, CliCommandOptions> = {
  */
 export async function increaseHandler({
   type,
-  dir
+  dir,
+  compose_file_name,
 }: CliCommandOptions): Promise<string> {
-  return await increaseFromLocalVersion({ type: type as ReleaseType, dir });
+  return await increaseFromLocalVersion({
+    type: type as ReleaseType,
+    dir,
+    compose_file_name
+  });
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -91,8 +91,10 @@ dappnodesdk build
 export async function initHandler({
   yes: useDefaults,
   force,
-  dir
+  dir,
+  compose_file_name,
 }: CliCommandOptions): Promise<Manifest> {
+  const composeFileName = compose_file_name;
   // shell outputs tend to include trailing spaces and new lines
   const directoryName = await shell('echo "${PWD##*/}"');
   const defaultAuthor = await shell("whoami");
@@ -191,7 +193,7 @@ It only covers the most common items, and tries to guess sensible defaults.
 
   // Write manifest and compose
   writeManifest(dir, manifest);
-  generateAndWriteCompose(dir, manifest);
+  generateAndWriteCompose(composeFileName, dir, manifest);
 
   // Add default avatar so users can run the command right away
   const files = fs.readdirSync(dir);

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -137,6 +137,7 @@ export async function publishHanlder({
   create_next_branch,
   dappnode_team_preset,
   // Global options
+  compose_file_name,
   dir,
   silent,
   verbose
@@ -153,6 +154,7 @@ export async function publishHanlder({
   let createNextGithubBranch = Boolean(create_next_branch);
   const developerAddress = developer_address || process.env.DEVELOPER_ADDRESS;
   const userTimeout = timeout;
+  const composeFileName = compose_file_name;
 
   const isCi = process.env.CI;
   const tag = process.env.TRAVIS_TAG || process.env.GITHUB_REF;
@@ -214,7 +216,8 @@ export async function publishHanlder({
             nextVersion = await increaseFromApmVersion({
               type: type as ReleaseType,
               ethProvider,
-              dir
+              dir,
+              composeFileName
             });
           } catch (e) {
             if (e.message.includes("NOREPO"))
@@ -234,6 +237,7 @@ export async function publishHanlder({
           new Listr(
             buildAndUpload({
               dir,
+              composeFileName,
               buildDir: ctx.buildDir,
               contentProvider,
               uploadTo,
@@ -249,6 +253,7 @@ export async function publishHanlder({
         task: ctx =>
           generatePublishTx({
             dir,
+            compose_file_name,
             releaseMultiHash: ctx.releaseMultiHash,
             developerAddress,
             ethProvider,
@@ -265,6 +270,7 @@ export async function publishHanlder({
         task: ctx =>
           createGithubRelease({
             dir,
+            compose_file_name,
             buildDir: ctx.buildDir,
             releaseMultiHash: ctx.releaseMultiHash,
             verbose,
@@ -280,6 +286,7 @@ export async function publishHanlder({
         task: () =>
           createNextBranch({
             dir,
+            compose_file_name,
             verbose,
             silent
           })

--- a/src/dappnodesdk.ts
+++ b/src/dappnodesdk.ts
@@ -28,6 +28,11 @@ const dappnodesdk = yargs
       default: "./",
       type: "string"
     },
+    compose_file_name: {
+      description: `Compose file for docker-compose`,
+      default: "docker-compose.yml",
+      type: "string"
+    },
     silent: {
       description: "Silence output to terminal",
       type: "boolean"

--- a/src/tasks/buildAndUpload.ts
+++ b/src/tasks/buildAndUpload.ts
@@ -47,6 +47,7 @@ export function buildAndUpload({
   userTimeout,
   skipSave,
   skipUpload,
+  composeFileName,
   dir
 }: {
   buildDir: string;
@@ -55,6 +56,7 @@ export function buildAndUpload({
   userTimeout: string;
   skipSave?: boolean;
   skipUpload?: boolean;
+  composeFileName: string;
   dir: string;
 }): ListrTask<ListrContextBuildAndPublish>[] {
   const buildTimeout = parseTimeout(userTimeout);
@@ -82,8 +84,8 @@ as ${releaseFilesDefaultNames.avatar} and then remove the 'manifest.avatar' prop
     throw new CliError("Package name in the manifest must be lowercase");
 
   // Update compose
-  const composePath = getComposePath(dir);
-  const composeForDev = readCompose(dir);
+  const composePath = getComposePath(composeFileName, dir);
+  const composeForDev = readCompose(composeFileName, dir);
   const composeForBuild = updateComposeImageTags(composeForDev, manifest);
   const composeForRelease = updateComposeImageTags(composeForDev, manifest, {
     editExternalImages: true
@@ -156,10 +158,10 @@ as ${releaseFilesDefaultNames.avatar} and then remove the 'manifest.avatar' prop
       title: "Copy files and validate",
       task: async () => {
         // Write compose with build props for builds
-        writeCompose(dir, composeForBuild);
+        writeCompose(composeFileName, dir, composeForBuild);
 
         // Copy files for release dir
-        writeCompose(buildDir, composeForRelease);
+        writeCompose(composeFileName, buildDir, composeForRelease);
         writeManifest(buildDir, manifest);
         validateManifest(manifest, { prerelease: true });
 

--- a/src/tasks/createNextBranch.ts
+++ b/src/tasks/createNextBranch.ts
@@ -12,8 +12,10 @@ import { Github } from "../utils/Github";
 export function createNextBranch({
   dir,
   verbose,
-  silent
+  silent,
+  compose_file_name,
 }: CliGlobalOptions): Listr<ListrContextBuildAndPublish> {
+  const composeFileName = compose_file_name;
   // Gather repo data, repoSlug = "dappnode/DNP_ADMIN"
   const github = new Github(dir);
 
@@ -38,10 +40,11 @@ export function createNextBranch({
             }
 
             const manifestPath = getManifestPath();
-            const composePath = getComposePath();
+            const composePath = getComposePath(composeFileName);
             const nextVersion = await increaseFromLocalVersion({
               type: "patch",
-              dir
+              dir,
+              compose_file_name
             });
             const branch = `v${nextVersion}`;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 
 export interface CliGlobalOptions {
   dir: string;
+  compose_file_name: string;
   silent?: boolean;
   verbose?: boolean;
 }

--- a/src/utils/compose.ts
+++ b/src/utils/compose.ts
@@ -13,15 +13,16 @@ import { upstreamImageLabel, UPSTREAM_VERSION_VARNAME } from "../params";
 import { toTitleCase } from "./format";
 import { mapValues, uniqBy } from "lodash";
 
-const composeFileName = "docker-compose.yml";
+// const defaultComposeFileName = "docker-compose.yml";
 
 /**
  * Get compose path. Without arguments defaults to './docker-compose.yml'
  *
+ * @param composeFileName: Name of compose file
  * @param dir: './folder', [optional] directory to load the manifest from
  * @return path = './dappnode_package.json'
  */
-export function getComposePath(dir = "./"): string {
+export function getComposePath(composeFileName: string, dir = "./"): string {
   return path.join(dir, composeFileName);
 }
 
@@ -29,22 +30,24 @@ export function getComposePath(dir = "./"): string {
  * Read the docker-compose.
  * Without arguments defaults to write the manifest at './docker-compose.yml'
  *
+ * @param composeFileName: Name of compose file
  * @param dir: './folder', [optional] directory to load the manifest from
  */
-export function generateAndWriteCompose(dir: string, manifest: Manifest): void {
+export function generateAndWriteCompose(composeFileName: string, dir: string, manifest: Manifest): void {
   const composeYaml = generateCompose(manifest);
-  writeCompose(dir, composeYaml);
+  writeCompose(composeFileName, dir, composeYaml);
 }
 
 /**
  * Read a compose data (string, without parsing)
  * Without arguments defaults to write the manifest at './docker-compose.yml'
  *
+ * @param composeFileName: Name of compose file
  * @param dir: './folder', [optional] directory to load the manifest from
  * @return compose object
  */
-export function readComposeString(dir: string): string {
-  const path = getComposePath(dir);
+export function readComposeString(composeFileName: string, dir: string): string {
+  const path = getComposePath(composeFileName, dir);
 
   // Recommended way of checking a file existance https://nodejs.org/api/fs.html#fs_fs_exists_path_callback
   let data;
@@ -53,7 +56,7 @@ export function readComposeString(dir: string): string {
   } catch (e) {
     if (e.code === "ENOENT") {
       throw Error(
-        `No docker-compose found at ${path}. Make sure you are in a directory with an initialized DNP.`
+        `${path} not found. Make sure you are in a directory with an initialized DNP.`
       );
     } else {
       throw e;
@@ -67,11 +70,12 @@ export function readComposeString(dir: string): string {
  * Read a compose parsed data
  * Without arguments defaults to write the manifest at './docker-compose.yml'
  *
+ * @param composeFileName: Name of compose file
  * @param dir: './folder', [optional] directory to load the manifest from
  * @return compose object
  */
-export function readCompose(dir: string): Compose {
-  const data = readComposeString(dir);
+export function readCompose(composeFileName: string, dir: string): Compose {
+  const data = readComposeString(composeFileName, dir);
 
   // Parse compose in try catch block to show a comprehensive error message
   try {
@@ -100,10 +104,9 @@ export function stringifyCompose(compose: Compose): string {
 
 /**
  * Writes the docker-compose.
- * Without arguments defaults to write the manifest at './docker-compose.yml'
  */
-export function writeCompose(dir: string, compose: Compose): void {
-  const path = getComposePath(dir);
+export function writeCompose(composeFileName: string, dir: string, compose: Compose): void {
+  const path = getComposePath(composeFileName, dir);
   fs.writeFileSync(path, stringifyCompose(compose));
 }
 

--- a/src/utils/versions/increaseFromApmVersion.ts
+++ b/src/utils/versions/increaseFromApmVersion.ts
@@ -6,11 +6,13 @@ import { ReleaseType } from "../../types";
 export async function increaseFromApmVersion({
   type,
   ethProvider,
-  dir
+  dir,
+  composeFileName
 }: {
   type: ReleaseType;
   ethProvider: string;
   dir: string;
+  composeFileName: string;
 }): Promise<string> {
   // Check variables
   const nextVersion = await getNextVersionFromApm({ type, ethProvider, dir });
@@ -24,8 +26,8 @@ export async function increaseFromApmVersion({
   // Mofidy and write the manifest and docker-compose
   writeManifest(dir, manifest);
   const { name, version } = manifest;
-  const compose = readCompose(dir);
-  writeCompose(dir, updateComposeImageTags(compose, { name, version }));
+  const compose = readCompose(composeFileName, dir);
+  writeCompose(composeFileName, dir, updateComposeImageTags(compose, { name, version }));
 
   return nextVersion;
 }

--- a/src/utils/versions/increaseFromLocalVersion.ts
+++ b/src/utils/versions/increaseFromLocalVersion.ts
@@ -6,11 +6,14 @@ import { ReleaseType } from "../../types";
 
 export async function increaseFromLocalVersion({
   type,
-  dir
+  dir,
+  compose_file_name
 }: {
   type: ReleaseType;
   dir: string;
+  compose_file_name: string;
 }): Promise<string> {
+  const composeFileName = compose_file_name;
   // Check variables
   checkSemverType(type);
 
@@ -36,8 +39,8 @@ export async function increaseFromLocalVersion({
   // Mofidy and write the manifest and docker-compose
   writeManifest(dir, manifest);
   const { name, version } = manifest;
-  const compose = readCompose(dir);
-  writeCompose(dir, updateComposeImageTags(compose, { name, version }));
+  const compose = readCompose(composeFileName, dir);
+  writeCompose(composeFileName, dir, updateComposeImageTags(compose, { name, version }));
 
   return nextVersion;
 }

--- a/test/tasks/buildAndUpload.test.ts
+++ b/test/tasks/buildAndUpload.test.ts
@@ -36,7 +36,8 @@ describe("buildAndUpload", () => {
     }
   };
   const manifestPath = "./dappnode_package.json";
-  const composePath = "./docker-compose.yml";
+  const composeFileName = 'docker-compose.yml';
+  const composePath = `./${composeFileName}`;
   const avatarPath = "./test-avatar.png";
   const avatarSourcePath = "test/test-avatar-source.png";
   const buildDir = `./build_${version}`;
@@ -77,6 +78,7 @@ ENV test=1
 
     const buildTasks = new Listr(
       buildAndUpload({
+        composeFileName,
         dir: "./",
         buildDir,
         contentProvider,

--- a/test/tasks/generatePublishTx.test.ts
+++ b/test/tasks/generatePublishTx.test.ts
@@ -14,6 +14,7 @@ import { rmSafe, mkdirSafe } from "../shellSafe";
 describe("generatePublishTx", () => {
   const manifestPath = "./dappnode_package.json";
   const buildDir = "dnp_0.0.0";
+  const compose_file_name = 'docker-compose.yml';
 
   before(async () => {
     await rmSafe(manifestPath);
@@ -29,6 +30,7 @@ describe("generatePublishTx", () => {
     fs.writeFileSync(manifestPath, stringifyManifest(manifest));
 
     const generatePublishTxTasks = generatePublishTx({
+      compose_file_name,
       dir: "./",
       releaseMultiHash: "/ipfs/Qm",
       developerAddress: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
@@ -61,6 +63,7 @@ describe("generatePublishTx", () => {
     fs.writeFileSync(manifestPath, stringifyManifest(manifest));
 
     const generatePublishTxTasks = generatePublishTx({
+      compose_file_name,
       dir: "./",
       releaseMultiHash: "/ipfs/Qm",
       developerAddress: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",

--- a/test/utils/versions/increaseFromApmVersion.test.ts
+++ b/test/utils/versions/increaseFromApmVersion.test.ts
@@ -18,6 +18,7 @@ import { stringifyManifest } from "../../../src/utils/manifest";
 
 describe("increaseFromApmVersion", () => {
   const ensName = "admin.dnp.dappnode.eth";
+
   const manifest: Manifest = {
     name: ensName,
     version: "0.1.0",
@@ -31,20 +32,22 @@ describe("increaseFromApmVersion", () => {
     }
   };
   const manifestPath = "./dappnode_package.json";
-  const composePath = "./docker-compose.yml";
+  const composeFileName = 'docker-compose.yml';
+  const composePath = `./${composeFileName}`;
   const dir = "./";
 
   before(async () => {
     await rmSafe(manifestPath);
     await rmSafe(composePath);
     fs.writeFileSync(manifestPath, stringifyManifest(manifest));
-    generateAndWriteCompose(dir, manifest);
+    generateAndWriteCompose(composeFileName, dir, manifest);
   });
 
   it("Should get the last version from APM", async () => {
     const nextVersion = await increaseFromApmVersion({
       type: "patch",
       ethProvider: "infura",
+      composeFileName,
       dir
     });
 

--- a/test/utils/versions/increaseFromLocalVersion.test.ts
+++ b/test/utils/versions/increaseFromLocalVersion.test.ts
@@ -30,19 +30,21 @@ describe("increaseFromLocalVersion", () => {
     }
   };
   const manifestPath = "./dappnode_package.json";
-  const composePath = "./docker-compose.yml";
+  const compose_file_name = 'docker-compose.yml';
+  const composePath = `./${compose_file_name}`;
   const dir = "./";
 
   before(async () => {
     await rmSafe(manifestPath);
     await rmSafe(composePath);
     fs.writeFileSync(manifestPath, stringifyManifest(manifest));
-    generateAndWriteCompose(dir, manifest);
+    generateAndWriteCompose(compose_file_name, dir, manifest);
   });
 
   it("Should get the last version from APM", async () => {
     const nextVersion = await increaseFromLocalVersion({
       type: "patch",
+      compose_file_name,
       dir
     });
 


### PR DESCRIPTION
Add option "--compose_file_name" to specify the compose file. Defaults to "docker-compose.yml".

Usecase:
We plan to build both DappNodePackage and "normal" containers from the same source tree. But this requires significant differences in docker-compose.yml (e.g. network settings, environment variables, volume definitions...).
So we need to keep two docker-compose.yml files - One for building the DAppNode package, one for normal usage with `docker-compose up`.
