### PR TITLE
Close old PRs on bump-upstream action

### DIFF
--- a/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
+++ b/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
@@ -13,7 +13,7 @@ export async function closeOldPrs(
 ): Promise<void> {
   // Get the url of the just opened PR for this branch
   const [newPr] = await thisRepo.getOpenPrsFromBranch({ branch: newBranch });
-  if (typeof newPr === "undefined") {
+  if (newPr === undefined) {
     throw Error(`No PR found for branch ${newBranch}`);
   }
 

--- a/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
+++ b/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
@@ -1,0 +1,53 @@
+import { branchNameRoot } from "../../../params";
+import { Github } from "../../../providers/github/Github";
+import { shell } from "../../../utils/shell";
+
+/**
+ * We only want one `bump-upstream` PR to be open since we likely
+ * want to always merge to the latest version. This step lists all
+ * PRs that start with the tag `branchNameRoot` and closes all but `branch`
+ */
+export async function closeOldPrs(
+  thisRepo: Github,
+  newBranch: string
+): Promise<void> {
+  // Get the url of the just opened PR for this branch
+  const [newPr] = await thisRepo.getOpenPrsFromBranch({ branch: newBranch });
+  if (typeof newPr === "undefined") {
+    throw Error(`No PR found for branch ${newBranch}`);
+  }
+
+  const allBranches = await thisRepo.listBranches();
+
+  for (const branchToDelete of allBranches) {
+    const oldBranch = branchToDelete.name;
+    try {
+      if (
+        // Only delete branches created by this bot = start with a known tag
+        oldBranch.startsWith(branchNameRoot) &&
+        // Keep the branch that was just created
+        oldBranch != newBranch
+      ) {
+        const prs = await thisRepo.getOpenPrsFromBranch({ branch: oldBranch });
+
+        for (const pr of prs) {
+          try {
+            // Comment the PR and close it
+            await thisRepo.commentPullRequest({
+              number: pr.number,
+              body: `Closing for newer version for ${newPr.html_url}`
+            });
+            await thisRepo.closePR(pr.number);
+          } catch (e) {
+            console.error(`Error commenting and closing PR ${pr.number}`, e);
+          }
+        }
+
+        // Remove the old branch
+        await shell(`git push origin --delete ${oldBranch}`);
+      }
+    } catch (e) {
+      console.error(`Error deleting the branch: ${e.message}`);
+    }
+  }
+}

--- a/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
+++ b/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
@@ -35,7 +35,7 @@ export async function closeOldPrs(
             // Comment the PR and close it
             await thisRepo.commentPullRequest({
               number: pr.number,
-              body: `Closing for newer version for ${newPr.html_url}`
+              body: `Newer version available, closing for ${newPr.html_url}`
             });
             await thisRepo.closePR(pr.number);
           } catch (e) {

--- a/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
+++ b/src/commands/githubActions/bumpUpstream/closeOldPrs.ts
@@ -47,7 +47,7 @@ export async function closeOldPrs(
         await shell(`git push origin --delete ${oldBranch}`);
       }
     } catch (e) {
-      console.error(`Error deleting the branch: ${e.message}`);
+      console.error(`Error deleting branch ${oldBranch}`, e);
     }
   }
 }

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -177,7 +177,7 @@ Compose - ${JSON.stringify(compose, null, 2)}
   try {
     await closeOldPrs(thisRepo, branch);
   } catch (e) {
-    console.log("Error on closeOldPrs", e);
+    console.error("Error on closeOldPrs", e);
   }
 
   const gitHead = await getGitHead();

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -212,16 +212,11 @@ Compose - ${JSON.stringify(compose, null, 2)}
             await thisRepo.closePR(number);
           } catch (e) {
             e.message = `Error Commenting and closing the PR: ${e.message}`;
-            throw e;
           }
         }
+
         // Remove the old branch
-        try {
-          console.log(await shell(`git checkout -b ${branchToDelete.name}`));
-        } catch (e) {
-          e.message = `Error Removing the branch: ${e.message}`;
-          throw e;
-        }
+        console.log(await shell(`git checkout -b ${branchToDelete.name}`));
       }
     } catch (e) {
       e.message = `Error deleting the branch: ${e.message}`;

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -180,6 +180,9 @@ Compose - ${JSON.stringify(compose, null, 2)}
 
   // to obtain the url and other info of the new PR
   const newPr = await thisRepo.getOpenPrsFromBranch({ branch });
+
+  if (!newPr) throw Error(`No PR found for branch ${branch}`);
+
   const newPrUrl = newPr[0].html_url; // get the link of the new PR
 
   const bodyComment = `Closing for newer version for ${newPrUrl}`;
@@ -211,7 +214,7 @@ Compose - ${JSON.stringify(compose, null, 2)}
             });
             await thisRepo.closePR(number);
           } catch (e) {
-            e.message = `Error Commenting and closing the PR: ${e.message}`;
+            console.error(`Error Commenting and closing the PR: ${e.message}`);
           }
         }
 
@@ -221,8 +224,7 @@ Compose - ${JSON.stringify(compose, null, 2)}
         );
       }
     } catch (e) {
-      e.message = `Error deleting the branch: ${e.message}`;
-      throw e;
+      console.error(`Error deleting the branch: ${e.message}`);
     }
   }
 

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -216,7 +216,9 @@ Compose - ${JSON.stringify(compose, null, 2)}
         }
 
         // Remove the old branch
-        console.log(await shell(`git checkout -b ${branchToDelete.name}`));
+        console.log(
+          await shell(`git push origin --delete ${branchToDelete.name}`)
+        );
       }
     } catch (e) {
       e.message = `Error deleting the branch: ${e.message}`;

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -215,8 +215,13 @@ Compose - ${JSON.stringify(compose, null, 2)}
             throw e;
           }
         }
-
-        console.log(await shell(`git checkout -b ${branchToDelete.name}`));
+        // Remove the old branch
+        try {
+          console.log(await shell(`git checkout -b ${branchToDelete.name}`));
+        } catch (e) {
+          e.message = `Error Removing the branch: ${e.message}`;
+          throw e;
+        }
       }
     } catch (e) {
       e.message = `Error deleting the branch: ${e.message}`;

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -181,7 +181,10 @@ Compose - ${JSON.stringify(compose, null, 2)}
   // to obtain the url and other info of the new PR
   const newPr = await thisRepo.getOpenPrsFromBranch({ branch });
 
-  if (!newPr) throw Error(`No PR found for branch ${branch}`);
+  //check if it exist this "PR"
+  if (typeof newPr[0] === "undefined") {
+    throw Error(`No PR found for branch ${branch}`);
+  }
 
   const newPrUrl = newPr[0].html_url; // get the link of the new PR
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -3,6 +3,12 @@ import { Architecture, FileFormat } from "./types";
 export class CliError extends Error {}
 export class YargsError extends Error {}
 
+// Github Actions params
+
+export const branchNameRoot = "dappnodebot/bump-upstream/";
+
+// DAppNode params
+
 export const defaultDir = "./";
 export const defaultManifestFileName = "dappnode_package.json";
 export const defaultComposeFileName = "docker-compose.yml";

--- a/src/providers/github/Github.ts
+++ b/src/providers/github/Github.ts
@@ -287,6 +287,24 @@ export class Github {
   }
 
   /**
+   * Comment a Pull Request
+   */
+  async commentPullRequest({
+    number,
+    body
+  }: {
+    number: number;
+    body: string;
+  }): Promise<void> {
+    await this.octokit.issues.createComment({
+      owner: this.owner,
+      repo: this.repo,
+      issue_number: number,
+      body
+    });
+  }
+
+  /**
    * Returns open PRs where head branch equals `branch`
    * Only branches and PRs originating from the same repo
    */

--- a/src/providers/github/Github.ts
+++ b/src/providers/github/Github.ts
@@ -364,4 +364,22 @@ export class Github {
       else throw e;
     }
   }
+
+  /**
+   * Close a PR
+   */
+
+  async closePR(pull_number: number): Promise<void> {
+    try {
+      this.octokit.pulls.update({
+        owner: this.owner,
+        repo: this.repo,
+        pull_number,
+        state: "closed"
+      });
+    } catch (e) {
+      e.message = `Error closing PR: ${e.message}`;
+      throw e;
+    }
+  }
 }


### PR DESCRIPTION
The workflow of the added code is:

1. Get the branches of the repo where the bot has created a new PR
2. Iterate these branches and filter (only affect branches created by the bot and older than the new one) and obtain the PR associated with
3.  Comment on the old PR's and close them. Then Delete the branch associated

Extra:
The deleting process is not done by the octokit library because the library does not offer that functionality.

Only we have to test with the dappnode bot.