### PR TITLE
Remove build prop before uploading files

### DIFF
--- a/src/tasks/buildAndUpload.ts
+++ b/src/tasks/buildAndUpload.ts
@@ -20,7 +20,8 @@ import {
   parseComposeUpstreamVersion,
   updateComposeImageTags,
   getComposePackageImages,
-  getComposePath
+  getComposePath,
+  composeDeleteBuildProperties
 } from "../utils/compose";
 import { ListrContextBuildAndPublish } from "../types";
 import { parseTimeout } from "../utils/timeout";
@@ -244,6 +245,10 @@ as ${releaseFilesDefaultNames.avatar} and then remove the 'manifest.avatar' prop
           fs.copyFileSync(imagePathAmd, imagePathLegacy);
 
         const gitHead = await getGitHeadIfAvailable({ requireGitData });
+
+        // Remove `build` property AFTER building. Otherwise it may break ISO installations
+        // https://github.com/dappnode/DAppNode_Installer/issues/161
+        composeDeleteBuildProperties({ dir: buildDir, composeFileName });
 
         ctx.releaseHash = await releaseUploader.addFromFs({
           dirPath: buildDir,

--- a/src/tasks/createGithubRelease.ts
+++ b/src/tasks/createGithubRelease.ts
@@ -11,12 +11,14 @@ import {
   ListrContextBuildAndPublish
 } from "../types";
 import { Github } from "../providers/github/Github";
+import { composeDeleteBuildProperties } from "../utils/compose";
 
 /**
  * Create (or edit) a Github release, then upload all assets
  */
 export function createGithubRelease({
   dir = defaultDir,
+  compose_file_name: composeFileName,
   buildDir,
   releaseMultiHash,
   verbose,
@@ -101,6 +103,10 @@ export function createGithubRelease({
           // only include their manifest and compose.
           // TODO: Track issue for a better solution https://github.com/dappnode/DNP_DAPPMANAGER/issues/570
           compactManifestIfCore(buildDir);
+
+          // Remove `build` property AFTER building. Otherwise it may break ISO installations
+          // https://github.com/dappnode/DAppNode_Installer/issues/161
+          composeDeleteBuildProperties({ dir: buildDir, composeFileName });
 
           task.output = `Creating release for tag ${tag}...`;
           await github.createReleaseAndUploadAssets(tag, {

--- a/src/utils/compose.ts
+++ b/src/utils/compose.ts
@@ -151,3 +151,14 @@ export function parseComposeUpstreamVersion(
         .map(({ name, version }) => (name ? `${name}: ${version}` : version))
         .join(", ");
 }
+
+/**
+ * Delete all `build` properties from all services in a disk persisted compose
+ */
+export function composeDeleteBuildProperties(paths?: ComposePaths): void {
+  const compose = readCompose(paths);
+  for (const service of Object.values(compose.services)) {
+    delete service.build;
+  }
+  writeCompose(compose, paths);
+}

--- a/test/utils/compose.test.ts
+++ b/test/utils/compose.test.ts
@@ -4,8 +4,12 @@ import { upstreamImageLabel } from "../../src/params";
 import {
   updateComposeImageTags,
   parseComposeUpstreamVersion,
-  getComposePackageImages
+  getComposePackageImages,
+  composeDeleteBuildProperties,
+  writeCompose,
+  readCompose
 } from "../../src/utils/compose";
+import { cleanTestDir, testDir } from "../testUtils";
 
 describe("util > compose", () => {
   describe("updateComposeImageTags", () => {
@@ -213,6 +217,41 @@ describe("util > compose", () => {
       const upstreamVersion = parseComposeUpstreamVersion(compose);
 
       expect(upstreamVersion).to.equal("v1.0.0");
+    });
+  });
+
+  describe("composeDeleteBuildProperties", () => {
+    after(() => {
+      cleanTestDir();
+    });
+
+    it("Should remove all build properties", () => {
+      const compose: Compose = {
+        version: "3.4",
+        services: {
+          test1: { image: "test:1", build: "." },
+          test2: {
+            image: "test:2",
+            build: { context: ".", args: { PARAM: "VALUE" } }
+          }
+        }
+      };
+
+      const composeEditedExpected: Compose = {
+        version: "3.4",
+        services: {
+          test1: { image: "test:1" },
+          test2: { image: "test:2" }
+        }
+      };
+
+      writeCompose(compose, { dir: testDir });
+
+      composeDeleteBuildProperties({ dir: testDir });
+
+      const composeEdited = readCompose({ dir: testDir });
+
+      expect(composeEdited).to.deep.equal(composeEditedExpected);
     });
   });
 });


### PR DESCRIPTION
When installing the DAppNode ISO compose services have the `build` property which must be removed. Otherwise if the image is not properly loaded on the user side docker may trigger a build that will fail.

To do that we use a `sed` statement in the ISO scripts which is nasty, since it manipulates YAML in a fragile way causing issues:
- If `build` is not immediately followed by `image` it will delete all content in between.

The SDK now removes the `build` property when publishing, so the installer doesn't have to do that.

Closes https://github.com/dappnode/DAppNodeSDK/issues/172
Related https://github.com/dappnode/DAppNode_Installer/issues/161