### PR TITLE
Allow manifest to be yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ dist
 # Test build files
 /build
 /build_*
-dappnode_package*.json
+dappnode_package*.*
 docker-compose.yml
 Dockerfile
 test-avatar.png
@@ -23,6 +23,8 @@ setup-ui.json
 disclaimer.md
 .cache
 .dappnodesdk-build-cache
+
+test_files/
 
 # Pinata envs for testing
 .env

--- a/src/commands/githubActions/build/cleanPinsFromDeletedBranches.ts
+++ b/src/commands/githubActions/build/cleanPinsFromDeletedBranches.ts
@@ -13,7 +13,7 @@ export async function cleanPinsFromDeletedBranches({
   dir: string;
 }): Promise<void> {
   // Read manifest from disk to get package name
-  const manifest = readManifest({ dir });
+  const { manifest } = readManifest({ dir });
 
   // Connect to Github Octokit REST API to know existing branches
   const github = Github.fromLocal(dir);

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -28,7 +28,7 @@ export const gaBumpUpstream: CommandModule<
 export async function gaBumpUpstreamHandler({
   dir = defaultDir
 }: CliGlobalOptions): Promise<void> {
-  const manifest = readManifest({ dir });
+  const { manifest, format } = readManifest({ dir });
   const compose = readCompose({ dir });
 
   const upstreamRepos = parseCsv(manifest.upstreamRepo);
@@ -142,7 +142,7 @@ Compose - ${JSON.stringify(compose, null, 2)}
 
   const versionsToUpdate = Array.from(versionsToUpdateMap.values());
   manifest.upstreamVersion = getUpstreamVersionTag(versionsToUpdate);
-  writeManifest(manifest, { dir });
+  writeManifest(manifest, format, { dir });
   writeCompose(compose, { dir });
 
   const commitMsg = `bump ${versionsToUpdate

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,6 +12,7 @@ import {
   defaultComposeFileName,
   defaultDir,
   defaultManifestFileName,
+  defaultManifestFormat,
   getImageTag,
   releaseFiles,
   YargsError
@@ -198,10 +199,8 @@ It only covers the most common items, and tries to guess sensible defaults.
   // Create package root dir
   fs.mkdirSync(dir, { recursive: true });
 
-  const manifestExists = fs.existsSync(getManifestPath({ dir }));
-  const composeExists = fs.existsSync(getComposePath({ dir }));
-
-  if (manifestExists && !force) {
+  const manifestPath = getManifestPath(defaultManifestFormat, { dir });
+  if (fs.existsSync(manifestPath) && !force) {
     const continueAnswer = await inquirer.prompt([
       {
         type: "confirm",
@@ -216,10 +215,10 @@ It only covers the most common items, and tries to guess sensible defaults.
   }
 
   // Write manifest and compose
-  writeManifest(manifest, { dir });
+  writeManifest(manifest, defaultManifestFormat, { dir });
 
   // Only write a compose if it doesn't exist
-  if (!composeExists) {
+  if (!fs.existsSync(getComposePath({ dir }))) {
     writeCompose(compose, { dir, composeFileName });
   }
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,4 +1,4 @@
-import { Architecture, FileFormat } from "./types";
+import { Architecture, FileFormat, ManifestFormat } from "./types";
 
 export class CliError extends Error {}
 export class YargsError extends Error {}
@@ -11,6 +11,7 @@ export const branchNameRoot = "dappnodebot/bump-upstream/";
 
 export const defaultDir = "./";
 export const defaultManifestFileName = "dappnode_package.json";
+export const defaultManifestFormat = ManifestFormat.json;
 export const defaultComposeFileName = "docker-compose.yml";
 export const publishTxAppUrl = "https://dappnode.github.io/sdk-publish/";
 export const UPSTREAM_VERSION_VARNAME = "UPSTREAM_VERSION";
@@ -29,7 +30,7 @@ export const contentHashFile = "content-hash";
 
 export const releaseFiles = {
   manifest: {
-    regex: /dappnode_package.*\.json$/,
+    regex: /dappnode_package.*\.(json|yaml|yml)$/,
     format: FileFormat.YAML,
     maxSize: 100e3, // Limit size to ~100KB
     required: true as const,

--- a/src/tasks/buildAndUpload.ts
+++ b/src/tasks/buildAndUpload.ts
@@ -71,7 +71,7 @@ export function buildAndUpload({
   const buildTimeout = parseTimeout(userTimeout);
 
   // Load manifest #### Todo: Deleted check functions. Verify manifest beforehand
-  const manifest = readManifest({ dir });
+  const { manifest, format } = readManifest({ dir });
 
   // Make sure the release is of correct type
   if ((manifest as any).image)
@@ -178,7 +178,7 @@ as ${releaseFilesDefaultNames.avatar} and then remove the 'manifest.avatar' prop
 
         // Copy files for release dir
         writeCompose(composeForRelease, { dir: buildDir, composeFileName });
-        writeManifest(manifest, { dir: buildDir });
+        writeManifest(manifest, format, { dir: buildDir });
         validateManifest(manifest);
 
         // Copy all other release files

--- a/src/tasks/generatePublishTx.ts
+++ b/src/tasks/generatePublishTx.ts
@@ -40,15 +40,15 @@ export function generatePublishTx({
   const apm = new Apm(ethProvider);
 
   // Load manifest ##### Verify manifest object
-  const { name, version } = readManifest({ dir });
+  const { manifest } = readManifest({ dir });
 
   // Compute tx data
   const contentURI =
     "0x" + Buffer.from(releaseMultiHash, "utf8").toString("hex");
   const contractAddress = "0x0000000000000000000000000000000000000000";
-  const currentVersion = version;
-  const ensName = name;
-  const shortName = name.split(".")[0];
+  const currentVersion = manifest.version;
+  const ensName = manifest.name;
+  const shortName = manifest.name.split(".")[0];
 
   return new Listr<ListrContextBuildAndPublish>(
     [
@@ -122,7 +122,7 @@ with command option:
            */
           addReleaseTx({
             dir,
-            version,
+            version: manifest.version,
             link: getPublishTxLink(ctx.txData)
           });
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export enum FileFormat {
   TEXT = "TEXT"
 }
 
+export enum ManifestFormat {
+  json = "json",
+  yml = "yml",
+  yaml = "yaml"
+}
+
 export type Architecture = "linux/amd64" | "linux/arm64";
 export const architectures: Architecture[] = ["linux/amd64", "linux/arm64"];
 export const defaultArch = "linux/amd64";

--- a/src/utils/compactManifest.ts
+++ b/src/utils/compactManifest.ts
@@ -10,7 +10,7 @@ import { readManifest, writeManifest } from "./manifest";
  * @param buildDir `build_0.1.0`
  */
 export function compactManifestIfCore(buildDir: string): void {
-  const manifest = readManifest({ dir: buildDir });
+  const { manifest, format } = readManifest({ dir: buildDir });
 
   if (manifest.type !== "dncore") return;
 
@@ -19,7 +19,7 @@ export function compactManifestIfCore(buildDir: string): void {
     manifest.setupWizard = setupWizard;
   }
 
-  writeManifest(manifest, { dir: buildDir });
+  writeManifest(manifest, format, { dir: buildDir });
 }
 
 function readSetupWizardIfExists(

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -1,8 +1,9 @@
 import fs from "fs";
 import path from "path";
+import yaml from "js-yaml";
 import prettier from "prettier";
-import { defaultDir, defaultManifestFileName } from "../params";
-import { Manifest } from "../types";
+import { defaultDir, releaseFiles } from "../params";
+import { Manifest, ManifestFormat } from "../types";
 import { readFile } from "./file";
 
 export interface ManifestPaths {
@@ -12,58 +13,111 @@ export interface ManifestPaths {
   manifestFileName?: string;
 }
 
+function parseFormat(filepath: string): ManifestFormat {
+  if (/.json$/.test(filepath)) return ManifestFormat.json;
+  if (/.yml$/.test(filepath)) return ManifestFormat.yml;
+  if (/.yaml$/.test(filepath)) return ManifestFormat.yaml;
+  throw Error(`Unsupported manifest format: ${filepath}`);
+}
+
 /**
  * Reads a manifest. Without arguments defaults to read the manifest at './dappnode_package.json'
  */
-export function readManifest(paths?: ManifestPaths): Manifest {
-  const manifestPath = getManifestPath(paths);
+export function readManifest(
+  paths?: ManifestPaths
+): { manifest: Manifest; format: ManifestFormat } {
+  // Figure out the path and format
+  const manifestPath = findManifestPath(paths);
+  const format = parseFormat(manifestPath);
   const data = readFile(manifestPath);
 
   // Parse manifest in try catch block to show a comprehensive error message
-  let manifest;
   try {
-    manifest = JSON.parse(data);
+    return {
+      format,
+      manifest: yaml.load(data)
+    };
   } catch (e) {
     throw Error(`Error parsing manifest: ${e.message}`);
   }
-
-  // Return manifest object
-  return manifest;
 }
 
 /**
  * Writes a manifest. Without arguments defaults to write the manifest at './dappnode_package.json'
  */
-export function writeManifest(manifest: Manifest, paths?: ManifestPaths): void {
-  const manifestPath = getManifestPath(paths);
-  fs.writeFileSync(manifestPath, stringifyJson(manifest));
+export function writeManifest(
+  manifest: Manifest,
+  format: ManifestFormat,
+  paths?: ManifestPaths
+): void {
+  const manifestPath = getManifestPath(format, paths);
+  fs.writeFileSync(manifestPath, stringifyJson(manifest, format));
 }
 
 /**
  * Get manifest path. Without arguments defaults to './dappnode_package.json'
  * @return path = './dappnode_package.json'
  */
-export function getManifestPath(paths?: ManifestPaths): string {
+export function findManifestPath(paths?: ManifestPaths): string {
+  const dirPath = paths?.dir || defaultDir;
+  if (paths?.manifestFileName) {
+    return path.join(dirPath, paths?.manifestFileName);
+  } else {
+    const files = fs.readdirSync(dirPath);
+    const filepath = files.find(file => releaseFiles.manifest.regex.test(file));
+    if (!filepath)
+      throw Error(
+        `No manifest found in directory ${dirPath}. Make sure you are in a directory with an initialized DNP.`
+      );
+    return path.join(dirPath, filepath);
+  }
+}
+
+/**
+ * Get manifest path. Without arguments defaults to './dappnode_package.json'
+ * @return path = './dappnode_package.json'
+ */
+export function getManifestPath(
+  format: ManifestFormat,
+  paths?: ManifestPaths
+): string {
   return path.join(
     paths?.dir || defaultDir,
-    paths?.manifestFileName || defaultManifestFileName
+    paths?.manifestFileName || `dappnode_package.${format}`
   );
 }
 
 /**
  * JSON.stringify + run prettier on the result
  */
-export function stringifyJson<T>(json: T): string {
-  return prettier.format(JSON.stringify(json, null, 2), {
-    // DAppNode prettier options, to match DAppNodeSDK + DAPPMANAGER
-    printWidth: 80,
-    tabWidth: 2,
-    useTabs: false,
-    semi: true,
-    singleQuote: false,
-    trailingComma: "none",
-    parser: "json"
-  });
+export function stringifyJson<T>(json: T, format: ManifestFormat): string {
+  switch (format) {
+    case ManifestFormat.json:
+      return prettier.format(JSON.stringify(json, null, 2), {
+        // DAppNode prettier options, to match DAppNodeSDK + DAPPMANAGER
+        printWidth: 80,
+        tabWidth: 2,
+        useTabs: false,
+        semi: true,
+        singleQuote: false,
+        trailingComma: "none",
+        parser: "json"
+      });
+
+    case ManifestFormat.yml:
+    case ManifestFormat.yaml:
+      return prettier.format(yaml.dump(json, { indent: 2 }), {
+        // DAppNode prettier options, to match DAppNodeSDK + DAPPMANAGER
+        printWidth: 80,
+        tabWidth: 2,
+        useTabs: false,
+        semi: true,
+        singleQuote: false,
+        trailingComma: "none",
+        // Built-in parser for YAML
+        parser: "yaml"
+      });
+  }
 }
 
 /**
@@ -74,7 +128,7 @@ export function stringifyJson<T>(json: T): string {
 export function getRepoSlugFromManifest(paths: ManifestPaths): string {
   const githubBaseUrl = "https://github.com/";
 
-  const manifest = readManifest(paths);
+  const { manifest } = readManifest(paths);
   const { type, url } = manifest.repository || {};
   // Ignore faulty manifests
   if (type !== "git" || !url || !url.includes(githubBaseUrl)) return "";

--- a/src/utils/releaseRecord.ts
+++ b/src/utils/releaseRecord.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { ManifestFormat } from "../types";
 import { stringifyJson } from "./manifest";
 
 interface ReleaseRecord {
@@ -42,7 +43,10 @@ function writeReleaseRecord(
       ...newReleaseRecord
     }
   };
-  fs.writeFileSync(releaseRecordPath, stringifyJson(mergedReleaseRecord));
+  fs.writeFileSync(
+    releaseRecordPath,
+    stringifyJson(mergedReleaseRecord, ManifestFormat.json)
+  );
 }
 
 export function addReleaseRecord({

--- a/src/utils/versions/getCurrentLocalVersion.ts
+++ b/src/utils/versions/getCurrentLocalVersion.ts
@@ -2,7 +2,7 @@ import { readManifest } from "../manifest";
 
 export function getCurrentLocalVersion({ dir }: { dir: string }): string {
   // Load manifest
-  const manifest = readManifest({ dir });
+  const { manifest } = readManifest({ dir });
   const currentVersion = manifest.version;
 
   return currentVersion;

--- a/src/utils/versions/getNextVersionFromApm.ts
+++ b/src/utils/versions/getNextVersionFromApm.ts
@@ -20,7 +20,7 @@ export async function getNextVersionFromApm({
   const apm = new Apm(ethProvider);
 
   // Load manifest
-  const manifest = readManifest({ dir });
+  const { manifest } = readManifest({ dir });
   const ensName = manifest.name.toLowerCase();
 
   // Fetch the latest version from APM

--- a/src/utils/versions/increaseFromApmVersion.ts
+++ b/src/utils/versions/increaseFromApmVersion.ts
@@ -18,13 +18,13 @@ export async function increaseFromApmVersion({
   const nextVersion = await getNextVersionFromApm({ type, ethProvider, dir });
 
   // Load manifest
-  const manifest = readManifest({ dir });
+  const { manifest, format } = readManifest({ dir });
 
   // Increase the version
   manifest.version = nextVersion;
 
   // Mofidy and write the manifest and docker-compose
-  writeManifest(manifest, { dir });
+  writeManifest(manifest, format, { dir });
   const { name, version } = manifest;
   const compose = readCompose({ dir, composeFileName });
   const newCompose = updateComposeImageTags(compose, { name, version });

--- a/src/utils/versions/increaseFromLocalVersion.ts
+++ b/src/utils/versions/increaseFromLocalVersion.ts
@@ -18,7 +18,7 @@ export async function increaseFromLocalVersion({
   checkSemverType(type);
 
   // Load manifest
-  const manifest = readManifest({ dir });
+  const { manifest, format } = readManifest({ dir });
 
   const currentVersion = manifest.version;
 
@@ -28,7 +28,7 @@ export async function increaseFromLocalVersion({
   manifest.version = nextVersion;
 
   // Mofidy and write the manifest and docker-compose
-  writeManifest(manifest, { dir });
+  writeManifest(manifest, format, { dir });
   const { name, version } = manifest;
   const compose = readCompose({ dir, composeFileName });
   const newCompose = updateComposeImageTags(compose, { name, version });

--- a/test/tasks/generatePublishTx.test.ts
+++ b/test/tasks/generatePublishTx.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { defaultManifestFormat } from "../../src/params";
 import { generatePublishTx } from "../../src/tasks/generatePublishTx";
 import { writeManifest } from "../../src/utils/manifest";
 import { testDir, cleanTestDir } from "../testUtils";
@@ -21,7 +22,7 @@ describe("generatePublishTx", function () {
       name: "admin.dnp.dappnode.eth",
       version: "0.1.0"
     };
-    writeManifest(manifest, { dir: testDir });
+    writeManifest(manifest, defaultManifestFormat, { dir: testDir });
 
     const generatePublishTxTasks = generatePublishTx({
       dir: testDir,
@@ -53,7 +54,7 @@ describe("generatePublishTx", function () {
       name: "new-repo.dnp.dappnode.eth",
       version: "0.1.0"
     };
-    writeManifest(manifest, { dir: testDir });
+    writeManifest(manifest, defaultManifestFormat, { dir: testDir });
 
     const generatePublishTxTasks = generatePublishTx({
       dir: testDir,

--- a/test/utils/versions/getNextVersionFromApm.test.ts
+++ b/test/utils/versions/getNextVersionFromApm.test.ts
@@ -3,6 +3,7 @@ import semver from "semver";
 import { getNextVersionFromApm } from "../../../src/utils/versions/getNextVersionFromApm";
 import { writeManifest } from "../../../src/utils/manifest";
 import { cleanTestDir, testDir } from "../../testUtils";
+import { defaultManifestFormat } from "../../../src/params";
 
 // This test will create the following fake files
 // ./dappnode_package.json  => fake manifest
@@ -21,7 +22,7 @@ describe("getNextVersionFromApm", function () {
   after("Clean testDir", () => cleanTestDir());
 
   it("Should get the last version from APM", async () => {
-    writeManifest(manifest, { dir: testDir });
+    writeManifest(manifest, defaultManifestFormat, { dir: testDir });
 
     const nextVersion = await getNextVersionFromApm({
       type: "patch",

--- a/test/utils/versions/increaseFromApmVersion.test.ts
+++ b/test/utils/versions/increaseFromApmVersion.test.ts
@@ -5,7 +5,10 @@ import { Manifest } from "../../../src/types";
 import { cleanTestDir, generateCompose, testDir } from "../../testUtils";
 import { readManifest, writeManifest } from "../../../src/utils/manifest";
 import { readCompose, writeCompose } from "../../../src/utils/compose";
-import { defaultComposeFileName } from "../../../src/params";
+import {
+  defaultComposeFileName,
+  defaultManifestFormat
+} from "../../../src/params";
 
 // This test will create the following fake files
 // ./dappnode_package.json  => fake manifest
@@ -29,7 +32,7 @@ describe("increaseFromApmVersion", function () {
   after("Clean testDir", () => cleanTestDir());
 
   it("Should get the last version from APM", async () => {
-    writeManifest(manifest, { dir: testDir });
+    writeManifest(manifest, defaultManifestFormat, { dir: testDir });
     writeCompose(generateCompose(manifest), { dir: testDir });
 
     const nextVersion = await increaseFromApmVersion({
@@ -49,7 +52,7 @@ describe("increaseFromApmVersion", function () {
       "compose should be edited to the next version"
     );
     // Check that the manifest was edited correctly to the next version
-    const newManifest = readManifest({ dir: testDir });
+    const { manifest: newManifest } = readManifest({ dir: testDir });
     expect(newManifest.version).to.equal(
       nextVersion,
       "manifest should be edited to the next version"

--- a/test/utils/versions/increaseFromLocalVersion.test.ts
+++ b/test/utils/versions/increaseFromLocalVersion.test.ts
@@ -3,7 +3,10 @@ import { increaseFromLocalVersion } from "../../../src/utils/versions/increaseFr
 import { readCompose, writeCompose } from "../../../src/utils/compose";
 import { readManifest, writeManifest } from "../../../src/utils/manifest";
 import { cleanTestDir, generateCompose, testDir } from "../../testUtils";
-import { defaultComposeFileName } from "../../../src/params";
+import {
+  defaultComposeFileName,
+  defaultManifestFormat
+} from "../../../src/params";
 
 // This test will create the following fake files
 // ./dappnode_package.json  => fake manifest
@@ -34,7 +37,7 @@ describe("increaseFromLocalVersion", function () {
   after("Clean testDir", () => cleanTestDir());
 
   it("Should get the last version from APM", async () => {
-    writeManifest(manifest, { dir: testDir });
+    writeManifest(manifest, defaultManifestFormat, { dir: testDir });
     writeCompose(generateCompose(manifest), { dir: testDir });
 
     const nextVersion = await increaseFromLocalVersion({
@@ -56,7 +59,7 @@ describe("increaseFromLocalVersion", function () {
       "compose should be edited to the next version"
     );
     // Check that the manifest was edited correctly to the next version
-    const newManifest = readManifest({ dir: testDir });
+    const { manifest: newManifest } = readManifest({ dir: testDir });
     expect(newManifest.version).to.equal(
       "0.1.1",
       "manifest should be edited to the next version"


### PR DESCRIPTION
Allow manifests to be YAML format, .yaml, .yml. Respects the original extension and applies formatting too.

Related to https://github.com/dappnode/DNP_DAPPMANAGER/pull/870