### PR TITLE
Fix License typo in manifest defaults GPL > GPL

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -115,7 +115,7 @@ export async function initHandler({
     avatar: "",
     type: "service",
     author: defaultAuthor,
-    license: "GLP-3.0"
+    license: "GPL-3.0"
   };
 
   if (!useDefaults) {


### PR DESCRIPTION
fixed the license typo in manifest defaults, so it no longer is the incorrect GLP-3.0 but the proper GPL-3.0. once it's pushed, then i won't need to keep fixing new package manifests after they're published.