### PR TITLE
Migrate node to SSL

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -166,7 +166,7 @@ export async function publishHanlder({
   if (dappnode_team_preset) {
     if (isCi) {
       ethProvider = "infura";
-      contentProvider = "http://ipfs.dappnode.io";
+      contentProvider = "https://api.ipfs.dappnode.io:443";
       uploadTo = "ipfs";
       // Activate verbose to see logs easier afterwards
       verbose = true;

--- a/src/releaseUploader/ipfsNode/ipfsProvider.ts
+++ b/src/releaseUploader/ipfsNode/ipfsProvider.ts
@@ -4,7 +4,7 @@ function getIpfsProviderUrl(provider = "dappnode"): string {
   if (provider === "dappnode") {
     return "http://ipfs.dappnode";
   } else if (provider === "remote") {
-    return "http://ipfs.dappnode.io";
+    return "https://api.ipfs.dappnode.io:443";
   } else if (provider === "infura") {
     return "https://ipfs.infura.io";
   } else {

--- a/test/commands/build.test.ts
+++ b/test/commands/build.test.ts
@@ -3,7 +3,7 @@ import { cleanTestDir, testDir } from "../testUtils";
 import { initHandler } from "../../src/commands/init";
 import { buildHandler } from "../../src/commands/build";
 
-const contentProvider = "http://ipfs.dappnode.io";
+const contentProvider = "https://api.ipfs.dappnode.io:443";
 
 // This test will create the following fake files
 // ./dappnode_package.json  => fake manifest


### PR DESCRIPTION
Change DAppNode's hosted endpoint to https://api.ipfs.dappnode.io