### PR TITLE
gitignore releases.json file

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,6 +8,7 @@ import { writeManifest, getManifestPath } from "../utils/manifest";
 import { writeCompose, getComposePath } from "../utils/compose";
 import defaultAvatar from "../assets/defaultAvatar";
 import { shell } from "../utils/shell";
+import { releasesRecordFileName } from "../utils/releaseRecord";
 import {
   defaultComposeFileName,
   defaultDir,
@@ -48,6 +49,7 @@ const gitignorePath = ".gitignore";
 const gitignoreCheck = "build_*";
 const gitignoreData = `# DAppNodeSDK release directories
 build_*
+${releasesRecordFileName}
 `;
 
 interface CliCommandOptions extends CliGlobalOptions {

--- a/src/utils/releaseRecord.ts
+++ b/src/utils/releaseRecord.ts
@@ -15,10 +15,10 @@ interface ReleaseRecords {
   [version: string]: ReleaseRecord;
 }
 
-const fileName = "releases.json";
+export const releasesRecordFileName = "releases.json";
 
 function readReleaseRecords(dir: string): ReleaseRecords {
-  const releaseRecordPath = path.join(dir, fileName);
+  const releaseRecordPath = path.join(dir, releasesRecordFileName);
   return fs.existsSync(releaseRecordPath)
     ? JSON.parse(fs.readFileSync(releaseRecordPath, "utf8"))
     : {};
@@ -34,7 +34,7 @@ function writeReleaseRecord(
   version: string,
   newReleaseRecord: Partial<ReleaseRecord>
 ): void {
-  const releaseRecordPath = path.join(dir, fileName);
+  const releaseRecordPath = path.join(dir, releasesRecordFileName);
   const releaseRecord = readReleaseRecords(dir);
   const mergedReleaseRecord = {
     ...releaseRecord,


### PR DESCRIPTION
This file is not meant to be committed, but a local offline record of the published versions you have done. To have a record of published versions we must use the releases page in Github.