### PR TITLE
Use single target build directory

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,19 +1,18 @@
-import path from "path";
 import chalk from "chalk";
 import { CommandModule } from "yargs";
 import Listr from "listr";
 // Tasks
 import { buildAndUpload } from "../tasks/buildAndUpload";
 // Utils
-import { getCurrentLocalVersion } from "../utils/versions/getCurrentLocalVersion";
 import { getInstallDnpLink } from "../utils/getLinks";
 import { CliGlobalOptions } from "../types";
 import { UploadTo } from "../releaseUploader";
-import { defaultComposeFileName, defaultDir } from "../params";
+import { defaultBuildDir, defaultComposeFileName, defaultDir } from "../params";
 
 interface CliCommandOptions extends CliGlobalOptions {
   provider: string;
   upload_to: UploadTo;
+  build_dir: string;
   timeout?: string;
   skip_save?: boolean;
   skip_upload?: boolean;
@@ -36,6 +35,11 @@ export const build: CommandModule<CliGlobalOptions, CliCommandOptions> = {
       description: `Specify where to upload the release`,
       choices: ["ipfs", "swarm"] as UploadTo[],
       default: "ipfs" as UploadTo
+    },
+    build_dir: {
+      description: "Target directory to write build files",
+      default: defaultBuildDir,
+      normalize: true
     },
     timeout: {
       alias: "t",
@@ -74,6 +78,7 @@ export async function buildHandler({
   provider,
   timeout,
   upload_to,
+  build_dir,
   skip_save,
   skip_upload,
   require_git_data,
@@ -91,13 +96,11 @@ export async function buildHandler({
   const skipSave = skip_save;
   const skipUpload = skip_save || skip_upload;
   const composeFileName = compose_file_name;
-  const nextVersion = getCurrentLocalVersion({ dir });
-  const buildDir = path.join(dir, `build_${nextVersion}`);
 
   const buildTasks = new Listr(
     buildAndUpload({
       dir,
-      buildDir,
+      buildDir: build_dir,
       contentProvider,
       uploadTo,
       userTimeout,

--- a/src/commands/githubActions/build/index.ts
+++ b/src/commands/githubActions/build/index.ts
@@ -1,6 +1,6 @@
 import { CommandModule } from "yargs";
 import { CliGlobalOptions } from "../../../types";
-import { defaultDir } from "../../../params";
+import { defaultBuildDir, defaultDir } from "../../../params";
 import { getGithubContext } from "../../../providers/github/githubActions";
 import { buildHandler } from "../../build";
 import { Github } from "../../../providers/github/Github";
@@ -74,6 +74,7 @@ export async function gaBuildHandler({
     await buildHandler({
       provider: "dappnode",
       upload_to: "ipfs",
+      build_dir: defaultBuildDir,
       skip_save: true,
       verbose: true
     });
@@ -99,6 +100,7 @@ export async function buildAndComment({
   const { releaseMultiHash } = await buildHandler({
     provider: "pinata",
     upload_to: "ipfs",
+    build_dir: defaultBuildDir,
     require_git_data: true,
     delete_old_pins: true,
     verbose: true

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,7 @@ import defaultAvatar from "../assets/defaultAvatar";
 import { shell } from "../utils/shell";
 import { releasesRecordFileName } from "../utils/releaseRecord";
 import {
+  defaultBuildDir,
   defaultComposeFileName,
   defaultDir,
   defaultManifestFileName,
@@ -46,11 +47,7 @@ ENTRYPOINT echo "happy buidl $USERNAME!"
 
 // .gitignore
 const gitignorePath = ".gitignore";
-const gitignoreCheck = "build_*";
-const gitignoreData = `# DAppNodeSDK release directories
-build_*
-${releasesRecordFileName}
-`;
+const gitignorePaths = [defaultBuildDir, releasesRecordFileName];
 
 interface CliCommandOptions extends CliGlobalOptions {
   yes?: boolean;
@@ -267,9 +264,16 @@ function getDnpName(name: string): string {
 function writeGitIgnore(filepath: string) {
   if (fs.existsSync(filepath)) {
     const currentGitignore = fs.readFileSync(filepath, "utf8");
-    if (!currentGitignore.includes(gitignoreCheck))
-      fs.writeFileSync(filepath, currentGitignore + gitignoreData);
+    const currentGitignorePaths = currentGitignore.split("\n");
+
+    for (const gitignorePath of gitignorePaths) {
+      if (!currentGitignorePaths.includes(gitignorePath)) {
+        currentGitignorePaths.push(gitignorePath);
+      }
+    }
+
+    fs.writeFileSync(filepath, currentGitignorePaths.join("\n"));
   } else {
-    fs.writeFileSync(filepath, gitignoreData);
+    fs.writeFileSync(filepath, gitignorePaths.join("\n"));
   }
 }

--- a/src/params.ts
+++ b/src/params.ts
@@ -7,6 +7,10 @@ export class YargsError extends Error {}
 
 export const branchNameRoot = "dappnodebot/bump-upstream/";
 
+// SDK params
+
+export const defaultBuildDir = "./build";
+
 // DAppNode params
 
 export const defaultDir = "./";

--- a/src/releaseUploader/pinata/addDirFromFs.ts
+++ b/src/releaseUploader/pinata/addDirFromFs.ts
@@ -4,7 +4,7 @@ import { PinataMetadata, PinataOptions, IpfsUploadResult } from "./PinataSDK";
 
 /**
  * Uploads a directory or file from the fs
- * @param dirOrFilePath "build_0.1.0/"
+ * @param dirOrFilePath "./build"
  * @param pinataUrl "https://api.pinata.cloud"
  * @param onProgress Reports upload progress, 0.4631
  * @returns "/ipfs/Qm..."

--- a/src/tasks/createGithubRelease.ts
+++ b/src/tasks/createGithubRelease.ts
@@ -119,7 +119,7 @@ export function createGithubRelease({
           });
 
           // Clean content hash file so the directory uploaded to IPFS is the same
-          // as the local build_* dir. User can then `ipfs add -r` and get the same hash
+          // as the local ./build dir. User can then `ipfs add -r` and get the same hash
           fs.unlinkSync(contentHashPath);
         }
       }

--- a/src/utils/compactManifest.ts
+++ b/src/utils/compactManifest.ts
@@ -7,7 +7,7 @@ import { readManifest, writeManifest } from "./manifest";
 /**
  * Reads manifest and extra files in `buildDir` compacts them in the manifest
  * and writes the resulting manifest in `buildDir`
- * @param buildDir `build_0.1.0`
+ * @param buildDir `./build`
  */
 export function compactManifestIfCore(buildDir: string): void {
   const { manifest, format } = readManifest({ dir: buildDir });

--- a/test/commands/build.test.ts
+++ b/test/commands/build.test.ts
@@ -31,6 +31,7 @@ describe("Init and build", function () {
       dir: testDir,
       provider: contentProvider,
       upload_to: "ipfs",
+      build_dir: "build",
       timeout: "5min",
       verbose: true
     });


### PR DESCRIPTION
When the dappnodesdk builds it uses the uncommon approach of creating a separate build directory for each version. This results in packages directories full of

```
build_0.2.0
build_0.2.1
build_0.2.2
build_0.2.3
build_0.2.4
```

This PR changes the behaviour to use the same target build regardless of version customizable with
```
--build_dir ./some_other_dir
```

If a user wants the same behaviour as before and keep backups of each version, just do

```
dappnodesdk build && cp -r build build_0.2.0
```

Extracted from https://github.com/dappnode/DAppNodeSDK/pull/213