### PR TITLE
Trigger manually CI with `workflow_dispatch`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  push:
+  workflow_dispatch:
     branches:
       - "master"
 
@@ -34,7 +34,8 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: tag
-    if: needs.tag.outputs.tag != ''
+
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Right now releases are triggered manually through a command `git tag..` by tagging the repo with the new release.

This is a manual action that must be done through a CLI. Instead, triggering CI manually from gha is a more straight forward action