### PR TITLE
Don't mutate compose on build

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -15,7 +15,6 @@ export const defaultManifestFormat = ManifestFormat.json;
 export const defaultComposeFileName = "docker-compose.yml";
 export const publishTxAppUrl = "https://dappnode.github.io/sdk-publish/";
 export const UPSTREAM_VERSION_VARNAME = "UPSTREAM_VERSION";
-export const upstreamImageLabel = "dappnode.dnp.upstreamImage";
 export const PINATA_URL = "https://api.pinata.cloud";
 
 /**

--- a/src/utils/compose.ts
+++ b/src/utils/compose.ts
@@ -7,7 +7,6 @@ import {
   defaultComposeFileName,
   defaultDir,
   getImageTag,
-  upstreamImageLabel,
   UPSTREAM_VERSION_VARNAME
 } from "../params";
 import { toTitleCase } from "./format";
@@ -80,28 +79,16 @@ function stringifyCompose(compose: Compose): string {
  */
 export function updateComposeImageTags(
   compose: Compose,
-  { name: dnpName, version }: { name: string; version: string },
-  options?: { editExternalImages?: boolean }
+  { name: dnpName, version }: { name: string; version: string }
 ): Compose {
   return {
     ...compose,
     services: mapValues(compose.services, (service, serviceName) => {
       const newImageTag = getImageTag({ dnpName, serviceName, version });
-      return service.build
-        ? {
-            ...service,
-            image: newImageTag
-          }
-        : options?.editExternalImages
-        ? {
-            ...service,
-            image: newImageTag,
-            labels: {
-              ...(service.labels || {}),
-              [upstreamImageLabel]: service.image
-            }
-          }
-        : service;
+      return {
+        ...service,
+        image: newImageTag
+      };
     })
   };
 }


### PR DESCRIPTION
buildAndUpload appears unnecessarily confusing in how it deals with the compose. There are multiple mutations and variations hard to reason about. Reasoning https://github.com/dappnode/DAppNodeSDK/issues/226

Closes https://github.com/dappnode/DAppNodeSDK/issues/226

**TODO**:
- [ ] Add re-tag logic for local and external images before save
- [ ] Ensure strictly one property service.image or service.build is defined
- [ ] Delete compose mutation code
- [ ] Test DAPPMANAGER doesn't break with a compose with service.image property