### PR TITLE
Move saveAndCompressImagesCached step to buildAndUpload

### DIFF
--- a/src/commands/from_github.ts
+++ b/src/commands/from_github.ts
@@ -8,8 +8,8 @@ import moment from "moment";
 import { CliGlobalOptions, defaultArch, Manifest } from "../types";
 import {
   contentHashFile,
-  getImagePath,
-  getLegacyImagePath,
+  getImageFilename,
+  getLegacyImageFilename,
   releaseFiles,
   releaseFilesDefaultNames
 } from "../params";
@@ -99,13 +99,13 @@ export async function fromGithubHandler({
     const { name, version }: Manifest = await got(
       manifestAsset.browser_download_url
     ).json();
-    const legacyImagePath = getLegacyImagePath(name, version);
+    const imageLegacyFilename = getLegacyImageFilename(name, version);
     const legacyImageAsset = release.assets.find(
-      asset => asset.name === legacyImagePath
+      asset => asset.name === imageLegacyFilename
     );
     if (legacyImageAsset) {
-      const imageAmdPath = getImagePath(name, version, defaultArch);
-      release.assets.push({ ...legacyImageAsset, name: imageAmdPath });
+      const imageAmdFilename = getImageFilename(name, version, defaultArch);
+      release.assets.push({ ...legacyImageAsset, name: imageAmdFilename });
     }
   }
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -129,12 +129,12 @@ export const releaseFilesDefaultNames: {
 // Single arch images
 export const getArchTag = (arch: Architecture): string =>
   arch.replace(/\//g, "-");
-export const getImagePath = (
+export const getImageFilename = (
   name: string,
   version: string,
   arch: Architecture
 ): string => `${name}_${version}_${getArchTag(arch)}.txz`;
-export const getLegacyImagePath = (name: string, version: string): string =>
+export const getLegacyImageFilename = (name: string, version: string): string =>
   `${name}_${version}.tar.xz`;
 
 /**

--- a/src/tasks/buildWithBuildx.ts
+++ b/src/tasks/buildWithBuildx.ts
@@ -2,7 +2,6 @@ import { ListrTask } from "listr";
 import semver from "semver";
 import { shell } from "../utils/shell";
 import { Architecture, PackageImage, PackageImageLocal } from "../types";
-import { saveAndCompressImagesCached } from "./saveAndCompressImages";
 import { getDockerVersion } from "../utils/getDockerVersion";
 
 const minimumDockerVersion = "19.3.0";
@@ -17,16 +16,12 @@ export function buildWithBuildx({
   architecture,
   images,
   composePath,
-  destPath,
-  buildTimeout,
-  skipSave
+  buildTimeout
 }: {
   architecture: Architecture;
   images: PackageImage[];
   composePath: string;
-  destPath: string;
   buildTimeout: number;
-  skipSave?: boolean;
 }): ListrTask[] {
   const localImages = images.filter(
     (image): image is PackageImageLocal => image.type === "local"
@@ -102,14 +97,6 @@ export function buildWithBuildx({
           }
         }
       }
-    },
-
-    ...saveAndCompressImagesCached({
-      images,
-      architecture,
-      destPath,
-      buildTimeout,
-      skipSave
-    })
+    }
   ];
 }

--- a/src/tasks/buildWithCompose.ts
+++ b/src/tasks/buildWithCompose.ts
@@ -1,7 +1,5 @@
 import { ListrTask } from "listr";
-import { defaultArch, PackageImage } from "../types";
 import { shell } from "../utils/shell";
-import { saveAndCompressImagesCached } from "./saveAndCompressImages";
 
 /**
  * Save docker image
@@ -9,17 +7,11 @@ import { saveAndCompressImagesCached } from "./saveAndCompressImages";
  * A local cache file will prevent unnecessary compressions if the image hasn't changed
  */
 export function buildWithCompose({
-  images,
   composePath,
-  destPath,
-  buildTimeout,
-  skipSave
+  buildTimeout
 }: {
-  images: PackageImage[];
   composePath: string;
-  destPath: string;
   buildTimeout: number;
-  skipSave?: boolean;
 }): ListrTask[] {
   return [
     {
@@ -32,14 +24,6 @@ export function buildWithCompose({
           onData: data => (task.output = data)
         });
       }
-    },
-
-    ...saveAndCompressImagesCached({
-      images,
-      architecture: defaultArch,
-      destPath,
-      buildTimeout,
-      skipSave
-    })
+    }
   ];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export enum ManifestFormat {
 
 export type Architecture = "linux/amd64" | "linux/arm64";
 export const architectures: Architecture[] = ["linux/amd64", "linux/arm64"];
-export const defaultArch = "linux/amd64";
+export const defaultArch = "linux/amd64" as const;
 
 export type ReleaseType = "major" | "minor" | "patch";
 export const releaseTypes: ReleaseType[] = ["major", "minor", "patch"];


### PR DESCRIPTION
Rationale https://github.com/dappnode/DAppNodeSDK/issues/225

- Move saveAndCompressImagesCached step to buildAndUpload
- Call saveAndCompressImagesCached only once
- Name full paths `*path` and file names `*filename`, for clarity on saveAndCompressImagesCached usage