### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false # don't cancel all jobs if some of them failed
       matrix:
-        node: ["10", "12"]
+        node: ["14", "16"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "homepage": "https://github.com/dappnode/DAppNodeSDK#readme",
   "dependencies": {
     "@octokit/rest": "^18.0.12",
-    "ajv": "^6.12.2",
-    "ajv-errors": "^1.0.1",
+    "ajv": "^8.11.0",
+    "ajv-errors": "^3.0.0",
     "async-retry": "^1.2.3",
     "chalk": "^2.4.2",
     "cli-progress": "^3.8.2",
@@ -63,7 +63,8 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
-    "@types/ajv-errors": "^1.0.2",
+    "@types/ajv": "^1.0.0",
+    "@types/ajv-errors": "^2.0.1",
     "@types/async-retry": "^1.4.2",
     "@types/chai": "^4.2.11",
     "@types/cli-progress": "^3.7.0",
@@ -87,7 +88,7 @@
     "eslint": "^7.3.1",
     "mocha": "^6.2.2",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.5"
+    "typescript": "^4.7.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/tasks/saveAndCompressImages.ts
+++ b/src/tasks/saveAndCompressImages.ts
@@ -139,7 +139,7 @@ async function saveAndCompressImages({
           Error(`Error compressing image: xz exit ${code} \n${lastStderr}`)
         );
       } else {
-        resolve();
+        resolve;
       }
     });
 

--- a/src/tasks/saveAndCompressImages.ts
+++ b/src/tasks/saveAndCompressImages.ts
@@ -139,7 +139,7 @@ async function saveAndCompressImages({
           Error(`Error compressing image: xz exit ${code} \n${lastStderr}`)
         );
       } else {
-        resolve;
+        resolve(`Compressed image saved to ${destPath}`);
       }
     });
 

--- a/src/utils/validateManifestSchema.ts
+++ b/src/utils/validateManifestSchema.ts
@@ -3,7 +3,11 @@ import ajvErrors from "ajv-errors";
 import manifestSchema from "../schemas/manifest.schema.json";
 import { Manifest } from "../types";
 
-const ajv = new Ajv({ allErrors: true });
+const ajv = new Ajv({
+  allErrors: true,
+  coerceTypes: true,
+  strictSchema: false
+});
 ajvErrors(ajv);
 // Precompile validator
 const validate = ajv.compile(manifestSchema);

--- a/src/utils/validateManifestSchema.ts
+++ b/src/utils/validateManifestSchema.ts
@@ -1,9 +1,9 @@
-import Ajv from "ajv";
+import Ajv, { ErrorObject } from "ajv";
 import ajvErrors from "ajv-errors";
 import manifestSchema from "../schemas/manifest.schema.json";
 import { Manifest } from "../types";
 
-const ajv = new Ajv({ allErrors: true, jsonPointers: true });
+const ajv = new Ajv({ allErrors: true });
 ajvErrors(ajv);
 // Precompile validator
 const validate = ajv.compile(manifestSchema);
@@ -80,8 +80,11 @@ export function validateManifestSchema(
  * @returns errorMessage:
  * "manifest.avatar should match pattern "^/(ipfs|bzz)/w+$""
  */
-function processError(errorObject: Ajv.ErrorObject): string {
-  const { dataPath, message } = errorObject;
-  const path = `manifest${dataPath}`.replace(new RegExp("/", "g"), ".");
+function processError(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errorObject: ErrorObject<string, Record<string, any>, unknown>
+): string {
+  const { schemaPath, message } = errorObject;
+  const path = `manifest${schemaPath}`.replace(new RegExp("/", "g"), ".");
   return `${path} ${message}`;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "types": ["mocha", "node"],
     "outDir": "dist",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "useUnknownInCatchVariables": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,10 +483,17 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@types/ajv-errors@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/ajv-errors/-/ajv-errors-1.0.2.tgz#963eadef9bfb51c47d110281433b626324a63329"
-  integrity sha512-lPgE0OZUGD9xZqj/83mSpdZzGQVY553/uCxmAEOSYUwlfW+azx/yYVUYZurmoiUhzRt+K4GKfOXPvKJmFdA6lg==
+"@types/ajv-errors@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ajv-errors/-/ajv-errors-2.0.1.tgz#8b6731ebd2abd3a2a4ccc23c04b2ba2b886adb51"
+  integrity sha512-rKqoLTrSQc0L5BzAINukDAHf9D9bVvIasKXCFkCzIXOn4SQFAMYcwl9oQyPKia8nkw4HnJzuoupKolniSDGicg==
+  dependencies:
+    ajv-errors "*"
+
+"@types/ajv@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/ajv/-/ajv-1.0.0.tgz#4fb2440742f2f6c30e7fb0797b839fc6f696682a"
+  integrity sha512-yGSqw9/QKd5FXbTNrSANcJ6IHWeNhA+gokXqmlPquJgLDC87d4g2FGPs+AlCeGG0GuZXmPq42hOFA2hnPymCLw==
   dependencies:
     ajv "*"
 
@@ -766,12 +773,12 @@ aes-js@3.0.0:
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
   integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
-ajv-errors@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
-  integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
+ajv-errors@*, ajv-errors@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
+  integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
 
-ajv@*, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2:
+ajv@*, ajv@^6.10.0, ajv@^6.10.2:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
@@ -789,6 +796,16 @@ ajv@^6.5.5:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-colors@3.2.3:
@@ -2055,6 +2072,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -2604,6 +2626,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -3021,10 +3048,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.9.5:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+typescript@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 universal-user-agent@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Update some important dependencies related to the JSON schema validation:
- `ajv` and `@types/ajv`
- `ajv-errors` and `@types/ajv-errors`
- `typescript`
- add `"useUnknownInCatchVariables": false` to `tsconfig.json`
- Update `validateSchema` options to not cras: `  coerceTypes: true, strictSchema: false`
- Update node matrix version in gha from 10/12 to 14/16
