### PR TITLE
Fix compose types

### DIFF
--- a/src/files/compose/types.ts
+++ b/src/files/compose/types.ts
@@ -104,14 +104,7 @@ export interface Compose {
   services: {
     [dnpName: string]: ComposeService;
   };
-  networks?: {
-    [networkName: string]: {
-      name?: string;
-      external?: boolean;
-      driver?: string; // "bridge";
-      ipam?: { config: { subnet: string }[] }; // { subnet: "172.33.0.0/16" }
-    };
-  };
+  networks?: ComposeNetwork;
   // { dappmanagerdnpdappnodeeth_data: {} };
   volumes?: ComposeVolumes;
 }

--- a/src/files/compose/types.ts
+++ b/src/files/compose/types.ts
@@ -58,6 +58,7 @@ export interface ComposeService {
   pid?: string;
   privileged?: boolean;
   restart?: string;
+  security_opt?: string;
   stop_grace_period?: string;
   stop_signal?: string;
   user?: string;

--- a/src/files/compose/types.ts
+++ b/src/files/compose/types.ts
@@ -104,7 +104,7 @@ export interface Compose {
   services: {
     [dnpName: string]: ComposeService;
   };
-  networks?: ComposeNetwork;
+  networks?: ComposeNetworks;
   // { dappmanagerdnpdappnodeeth_data: {} };
   volumes?: ComposeVolumes;
 }

--- a/src/files/compose/types.ts
+++ b/src/files/compose/types.ts
@@ -74,7 +74,7 @@ export interface ComposeServiceNetwork {
   aliases?: string[];
 }
 
-export type ComposeServiceNetworks = string[] | ComposeServiceNetworksObj[];
+export type ComposeServiceNetworks = string[] | ComposeServiceNetworksObj;
 
 export type ComposeServiceNetworksObj = {
   [networkName: string]: ComposeServiceNetwork;
@@ -112,12 +112,25 @@ export interface Compose {
     };
   };
   // { dappmanagerdnpdappnodeeth_data: {} };
-  volumes?: {
-    [volumeName: string]: {
-      // NOTE: Not allowed
-      external?: boolean | { name: string }; // name: "dncore_ipfsdnpdappnodeeth_data"
-    };
-  };
+  volumes?: ComposeVolumes;
+}
+
+export interface ComposeVolumes {
+  /** volumeName: "dncore_ipfsdnpdappnodeeth_data" */
+  [volumeName: string]: ComposeVolume | null;
+}
+
+export interface ComposeVolume {
+  // FORBIDDEN
+  // external?: boolean | { name: string }; // name: "dncore_ipfsdnpdappnodeeth_data"
+  // NOT allowed to user, only used by DAppNode internally (if any)
+  external?: boolean;
+  name?: string; // Volumes can only be declared locally or be external
+  driver?: string; // Dangerous
+  driver_opts?:
+    | { type: "none"; device: string; o: "bind" }
+    | { [driverOptName: string]: string }; // driver_opts are passed down to whatever driver is being used, there's. No verification on docker's part nor detailed documentation
+  labels?: { [labelName: string]: string }; // User should not use this feature
 }
 
 export interface ComposePaths {

--- a/src/files/compose/validateDappnodeCompose.ts
+++ b/src/files/compose/validateDappnodeCompose.ts
@@ -75,7 +75,8 @@ function validateComposeNetworks(compose: Compose): void {
           )} are allowed`
         );
       // Check all networks are external
-      if (networks[networkName].external === false)
+      const network = networks[networkName];
+      if (network && network.external === false)
         err(
           `The docker network ${networkName} is not allowed. Docker internal networks are not allowed`
         );

--- a/src/files/compose/validateDappnodeCompose.ts
+++ b/src/files/compose/validateDappnodeCompose.ts
@@ -156,36 +156,34 @@ function validateComposeServiceNetworks(
   const serviceNetworks = service.networks;
   if (!serviceNetworks) return;
 
-  for (const serviceNetwork of serviceNetworks) {
-    if (typeof serviceNetwork === "string") {
+  if (Array.isArray(serviceNetworks)) {
+    for (const serviceNetwork of serviceNetworks) {
       // Check docker network is whitelisted when defined in array format
       if (!params.DOCKER_WHITELIST_NETWORKS.includes(serviceNetwork))
         err(
           `service ${serviceName} has a non-whitelisted docker network: ${serviceNetwork}. Only docker networks ${DOCKER_WHITELIST_NETWORKS_STR} are allowed`
         );
-    } else {
-      for (const serviceNetworkObjectName of Object.keys(serviceNetwork)) {
-        // Check docker network is whitelisted when defined in object format
-        if (
-          !params.DOCKER_WHITELIST_NETWORKS.includes(serviceNetworkObjectName)
-        )
-          err(
-            `service ${serviceName} has a non-whitelisted docker network: ${serviceNetworkObjectName}. Only docker networks ${DOCKER_WHITELIST_NETWORKS_STR} are allowed`
-          );
+    }
+  } else {
+    for (const serviceNetworkObjectName of Object.keys(serviceNetworks)) {
+      // Check docker network is whitelisted when defined in object format
+      if (!params.DOCKER_WHITELIST_NETWORKS.includes(serviceNetworkObjectName))
+        err(
+          `service ${serviceName} has a non-whitelisted docker network: ${serviceNetworkObjectName}. Only docker networks ${DOCKER_WHITELIST_NETWORKS_STR} are allowed`
+        );
 
-        // Check core aliases are not used by non core packages
-        const { aliases } = serviceNetwork[serviceNetworkObjectName];
-        if (
-          !isCore &&
-          aliases &&
-          params.DOCKER_CORE_ALIASES.some(coreAlias =>
-            aliases.includes(coreAlias)
-          )
-        ) {
-          err(
-            `service ${serviceName} has the network ${serviceNetworkObjectName} with reserved docker alias. Aliases ${DOCKER_WHITELIST_ALIASES_STR} are reserved to core packages`
-          );
-        }
+      // Check core aliases are not used by non core packages
+      const { aliases } = serviceNetworks[serviceNetworkObjectName];
+      if (
+        !isCore &&
+        aliases &&
+        params.DOCKER_CORE_ALIASES.some(coreAlias =>
+          aliases.includes(coreAlias)
+        )
+      ) {
+        err(
+          `service ${serviceName} has the network ${serviceNetworkObjectName} with reserved docker alias. Aliases ${DOCKER_WHITELIST_ALIASES_STR} are reserved to core packages`
+        );
       }
     }
   }

--- a/src/files/manifest/types.ts
+++ b/src/files/manifest/types.ts
@@ -118,15 +118,15 @@ interface Dependencies {
 
 // Driver
 
-type ChainDriver = ChainDriverType | ChainDriverSpecs;
+export type ChainDriver = ChainDriverType | ChainDriverSpecs;
 
-type ChainDriverSpecs = {
+export type ChainDriverSpecs = {
   driver: ChainDriverType;
   serviceName?: string;
   portNumber?: number;
 };
 
-type ChainDriverType =
+export type ChainDriverType =
   | "bitcoin"
   | "ethereum"
   | "ethereum-beacon-chain"

--- a/test/files/compose/validateDappnodeCompose.test.ts
+++ b/test/files/compose/validateDappnodeCompose.test.ts
@@ -211,18 +211,16 @@ service validator has a non-whitelisted docker network: danger_network. Only doc
             ...compose.services,
             validator: {
               ...compose.services.validator,
-              networks: [
-                {
-                  danger_network: {
-                    ipv4_address: "172.33.4.5",
-                    aliases: ["dappmanager.dappnode"]
-                  },
-                  other_network: {
-                    ipv4_address: "",
-                    aliases: ["core.dappnode"]
-                  }
+              networks: {
+                danger_network: {
+                  ipv4_address: "172.33.4.5",
+                  aliases: ["dappmanager.dappnode"]
+                },
+                other_network: {
+                  ipv4_address: "",
+                  aliases: ["core.dappnode"]
                 }
-              ]
+              }
             }
           }
         },


### PR DESCRIPTION
Fix compose types:
- Add `ComposeVolumes` types
- Fix `ComposeNetworks` from `export type ComposeServiceNetworks = string[] | ComposeServiceNetworksObj[];` to `export type ComposeServiceNetworks = string[] | ComposeServiceNetworksObj;`
- Add `security_opt` key to compose service key whitelisted