### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: tag
-    if: needs.tag.outputs.is_update != 'false'
+    if: needs.tag.outputs.is_update == 'true'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   tag:
+    name: Get latest tag
     runs-on: ubuntu-latest
     outputs:
       latest_version: ${{ steps.npm-version.outputs.latest_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.tag.outputs.tag }}
-          release_name: Release ${{ needs.tag.outputs.tag }}
+          tag_name: ${{ needs.tag.outputs.latest_git_tag }}
+          release_name: Release ${{ needs.tag.outputs.latest_git_tag }}
 
       - name: Publish to npm registry
         run: npm publish --access public
@@ -68,10 +68,10 @@ jobs:
       # In case of failure
       - name: Rollback on failure
         if: failure()
-        uses: author/action-rollback@9ec72a6af74774e00343c6de3e946b0901c23013
+        uses: author/action-rollback@9ec72ca6af74774e00343c6de3e946b0901c23013
         with:
           id: ${{ steps.create_release.outputs.id }}
-          tag: ${{ needs.tag.outputs.tag }}
+          tag: ${{ needs.tag.outputs.latest_git_tag }}
           delete_orphan_tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,34 +7,41 @@ on:
 
 jobs:
   tag:
-    name: Check and Tag
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+    outputs:
+      latest_version: ${{ steps.npm-version.outputs.latest_version }}
+      latest_git_tag: ${{ steps.get-latest-git-tag.outputs.tag }}
+      is_update: ${{ steps.is-update.outputs.is_update }}
 
-      - name: Get latest tag
+    steps:
+      - name: Get latest version from NPM
+        id: npm-version
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
+          registry-url: https://registry.npmjs.org/
+        run: echo "::set-output name=latest_version::$(npx run @dappnode/dappnodesdk --version)"
+    
+      - name: Get latest tag from git
+        id: get-latest-git-tag
         uses: actions-ecosystem/action-get-latest-tag@v1
         with:
           with_initial_version: false
-        id: get-latest-tag
 
-      - name: Create tag
-        id: tag
-        uses: butlerlogic/action-autotag@1.1.1
-        with:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          tag_prefix: "v"
-    outputs:
-      tag: ${{ steps.tag.outputs.tagname }}
-      previous_tag: ${{ steps.get-latest-tag.outputs.tag }}
-      version: ${{ steps.tag.outputs.version }}
+      - name: Check if latest tag is greater than the one published in npm
+        id: is-update
+        run: |
+          if [ "${{ steps.npm-version.outputs.latest_version }}" != "${{ steps.get-latest-git-tag.outputs.tag }}" ]; then
+            echo "::set-output name=is_update::true"
+          else
+            echo "::set-output name=is_update::false"
+          fi
 
   release:
     name: Publish
     runs-on: ubuntu-latest
     needs: tag
-    if: needs.tag.outputs.tag != ''
+    if: needs.tag.outputs.is_update != 'false'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -44,23 +51,6 @@ jobs:
       - run: yarn install
       - run: yarn build
 
-      - name: Generate changelog
-        id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issues: "false"
-          pullRequests: "true"
-          prWoLabels: "true"
-          author: "true"
-          usernamesAsGithubLogins: "true"
-          compareLink: "true"
-          filterByMilestone: "false"
-          unreleased: "false"
-          sinceTag: "${{ needs.tag.outputs.previous_tag }}"
-          maxIssues: "0"
-          stripGeneratorNotice: "true"
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -68,7 +58,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
-          body_path: "CHANGELOG.md"
           release_name: Release ${{ needs.tag.outputs.tag }}
 
       - name: Publish to npm registry


### PR DESCRIPTION
**Issue**

The current CI to release the SDK to NPM is broken.

The command to trigger the release is 
```
"tag-and-publish": "npm version patch && git push origin master && git push --tags"
```
The issue seems to be that the above command pushes the git tags created by `npm version patch` so [this action](https://github.com/dappnode/DAppNodeSDK/blob/c8eef65d7780d8cf2120d3fbcc0be2ebfb673191/.github/workflows/release.yml#L22) does not create any new tag which in the end makes the [publish to not be triggered](https://github.com/dappnode/DAppNodeSDK/blob/c8eef65d7780d8cf2120d3fbcc0be2ebfb673191/.github/workflows/release.yml#L37)

**Fix**
Because the tags are pushed to master, trigger the action by comparing the following values:
- Latest dappnodesdk version from NPM registry
- Latest git tag

If the Latest git tag is greater then it is an update and the publish action should be triggered