### PR TITLE
Allow union types

### DIFF
--- a/src/schemaValidation/validateSchema.ts
+++ b/src/schemaValidation/validateSchema.ts
@@ -11,7 +11,8 @@ import { Compose, Manifest } from "../files";
 const ajv = new Ajv({
   allErrors: true,
   coerceTypes: true,
-  strictSchema: false
+  strictSchema: false,
+  allowUnionTypes: true
 });
 
 ajvErrors(ajv);


### PR DESCRIPTION
Allow union types used by the compose JSON schema.

Ajv `allowUnionTypes` ref https://ajv.js.org/strict-mode.html#union-types