### PR TITLE
Add whitelist to use docker bind volumes

### DIFF
--- a/src/files/compose/params.ts
+++ b/src/files/compose/params.ts
@@ -3,6 +3,14 @@ export const params = {
   CONTAINER_CORE_NAME_PREFIX: "DAppNodeCore-",
   CONTAINER_TOOL_NAME_PREFIX: "DAppNodeTool-",
   DOCKER_WHITELIST_NETWORKS: ["dncore_network", "dnpublic_network"],
+  DOCKER_WHITELIST_BIND_VOLUMES: [
+    "dappmanager.dnp.dappnode.eth",
+    "wifi.dnp.dappnode.eth",
+    "vpn.dnp.dappnode.eth",
+    "wireguard.dnp.dappnode.eth",
+    "core.dnp.dappnode.eth",
+    "dappnode-exporter.dnp.dappnode.eth"
+  ],
   DOCKER_CORE_ALIASES: [
     "dappmanager.dappnode",
     "wifi.dappnode",
@@ -41,6 +49,8 @@ export const params = {
     "build",
     "volumes",
     "environment",
-    "pid"
+    "pid",
+    "container_name",
+    "dns"
   ]
 };

--- a/src/files/compose/validateDappnodeCompose.ts
+++ b/src/files/compose/validateDappnodeCompose.ts
@@ -33,7 +33,7 @@ export function validateDappnodeCompose(
   const servicesNames = Object.keys(compose.services);
 
   for (const serviceName of servicesNames) {
-    validateComposeService(compose, isCore, serviceName);
+    validateComposeService(compose, isCore, serviceName, manifest.name);
   }
 
   if (aggregatedError.length > 0)
@@ -90,7 +90,8 @@ function validateComposeNetworks(compose: Compose): void {
 function validateComposeService(
   compose: Compose,
   isCore: boolean,
-  serviceName: string
+  serviceName: string,
+  dnpName: string
 ): void {
   for (const serviceKey of Object.keys(compose.services[serviceName])) {
     if (!params.SAFE_KEYS.includes(serviceKey))
@@ -127,7 +128,7 @@ function validateComposeService(
 
   validateComposeServiceNetworks(compose, isCore, serviceName);
 
-  if (volumes) {
+  if (volumes && !params.DOCKER_WHITELIST_BIND_VOLUMES.includes(dnpName)) {
     for (const [i, volume] of volumes.entries()) {
       if (typeof volume !== "string") {
         // https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3


### PR DESCRIPTION
Add whitelist to use docker bind volumes: wifi, wireguard, vpn, core, exporter and dappmanager

See discussion https://github.com/dappnode/DAppNode/issues/451