### PR TITLE
Bypass compose JSON schema validation

### DIFF
--- a/src/tasks/buildAndUpload.ts
+++ b/src/tasks/buildAndUpload.ts
@@ -187,8 +187,9 @@ as ${releaseFilesDefaultNames.avatar} and then remove the 'manifest.avatar' prop
               validateManifestSchema(manifest);
               break;
             case "compose":
-              // validate against official docker compose schema
-              validateComposeSchema(composeForDev);
+              // validate against official docker compose schema. Bypass until fix:
+              // validateComposeSchema(composeForDev):
+
               // validate against custom dappnode requirements
               validateDappnodeCompose(composeForDev, manifest);
               break;


### PR DESCRIPTION
Related to https://github.com/dappnode/DAppNodeSDK/issues/250

Bypass the compose schema validation until got fixed