### PR TITLE
Setup wizard: allow service to be an array for env variables

### DIFF
--- a/src/schemaValidation/schemas/setup-wizard.schema.json
+++ b/src/schemaValidation/schemas/setup-wizard.schema.json
@@ -42,7 +42,11 @@
                     "example": ["PAYOUT_ADDRESS"]
                   },
                   "service": {
-                    "type": "string",
+                    "type": ["string", "array"],
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
                     "title": "Service to target",
                     "description": "In multi-service package, which service should be targeted",
                     "example": ["service1", "service2"]

--- a/test/schemaValidation/validateSchema.test.ts
+++ b/test/schemaValidation/validateSchema.test.ts
@@ -126,7 +126,7 @@ fields:
     target:
       type: environment
       name: HTTP_WEB3PROVIDER
-      service: beacon-chain
+      service: [validator, beacon-chain]
     title: Eth1.x node URL
     description: >-
       URL to the Eth1.x node need for the Beacon chain.
@@ -198,6 +198,25 @@ fields:
       Get your checkpoint sync from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-prater.infura.io)
     required: false
   - notAllowed: random`;
+
+      fs.writeFileSync(setupWizardPath, invalidSetupWizardString);
+
+      expect(() => validateSetupWizardSchema(testDir)).to.throw();
+    });
+
+    it("should throw error with an empty service array in setupWizard", () => {
+      const invalidSetupWizardString = `
+version: "2"
+fields:
+  - id: GRAFFITI
+    target:
+      type: environment
+      name: GRAFFITI
+      service: []
+    title: Graffiti
+    maxLength: 32
+    description: >-
+      Add a string to your proposed blocks, which will be seen on the block explorer`
 
       fs.writeFileSync(setupWizardPath, invalidSetupWizardString);
 


### PR DESCRIPTION
Allowed `service` to be an array of strings with at least 1 item