### PR TITLE
Add to `globalEnvs` the string array option

### DIFF
--- a/src/files/manifest/types.ts
+++ b/src/files/manifest/types.ts
@@ -46,9 +46,11 @@ export interface Manifest {
   requirements?: {
     minimumDappnodeVersion: string;
   };
-  globalEnvs?: {
-    all?: boolean;
-  };
+  globalEnvs?:
+    | {
+        all?: boolean;
+      }
+    | string[];
   architectures?: Architecture[];
 
   // Safety properties to solve problematic updates

--- a/src/files/manifest/types.ts
+++ b/src/files/manifest/types.ts
@@ -50,7 +50,10 @@ export interface Manifest {
     | {
         all?: boolean;
       }
-    | string[];
+    | {
+        envs: string[];
+        services: string[];
+      }[];
   architectures?: Architecture[];
 
   // Safety properties to solve problematic updates

--- a/src/schemaValidation/schemas/manifest.schema.json
+++ b/src/schemaValidation/schemas/manifest.schema.json
@@ -155,7 +155,28 @@
           "type": "array",
           "description": "Request the DAPPMANAGER to inject the selected global ENVs to this package's containers",
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "envs": {
+                "type": "array",
+                "description": "The list of envs to inject to the defined services",
+                "items": {
+                  "type": "string",
+                  "examples": [
+                    "_DAPPNODE_GLOBAL_NO_NAT_LOOPBACK",
+                    "_DAPPNODE_GLOBAL_PUBLIC_IP"
+                  ]
+                },
+                "services": {
+                  "type": "array",
+                  "description": "The services to inject the global ENVs to",
+                  "items": {
+                    "type": "string",
+                    "examples": ["webserver", "backend", "service1"]
+                  }
+                }
+              }
+            }
           }
         },
         {

--- a/src/schemaValidation/schemas/manifest.schema.json
+++ b/src/schemaValidation/schemas/manifest.schema.json
@@ -150,15 +150,26 @@
       }
     },
     "globalEnvs": {
-      "type": "object",
-      "description": "Request the DAPPMANAGER to inject global ENVs to this package's containers",
-      "properties": {
-        "all": {
-          "type": "boolean",
-          "description": "Request the DAPPMANAGER to inject all available global ENVs",
-          "examples": ["true"]
+      "oneOf": [
+        {
+          "type": "array",
+          "description": "Request the DAPPMANAGER to inject the selected global ENVs to this package's containers",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object",
+          "description": "Request the DAPPMANAGER to inject global ENVs to this package's containers",
+          "properties": {
+            "all": {
+              "type": "boolean",
+              "description": "Request the DAPPMANAGER to inject all available global ENVs",
+              "examples": ["true"]
+            }
+          }
         }
-      }
+      ]
     },
     "architectures": {
       "type": "array",

--- a/test/schemaValidation/validateSchema.test.ts
+++ b/test/schemaValidation/validateSchema.test.ts
@@ -11,6 +11,38 @@ import { cleanTestDir, testDir } from "../testUtils";
 
 describe("schemaValidation", () => {
   describe("manifest", () => {
+    it("validateManifest globalEnvs as array of strings", () => {
+      const manifest: Manifest = {
+        name: "",
+        version: "1.0.0",
+        description: "",
+        type: "dncore",
+        license: "1",
+        globalEnvs: ["_first_env", "_second_env"],
+        chain: {
+          driver: "ethereum"
+        }
+      };
+
+      expect(() => validateManifestSchema(manifest)).to.not.throw();
+    });
+
+    it("validateManifest globalEnvs as object", () => {
+      const manifest: Manifest = {
+        name: "",
+        version: "1.0.0",
+        description: "",
+        type: "dncore",
+        license: "1",
+        globalEnvs: { all: true },
+        chain: {
+          driver: "ethereum"
+        }
+      };
+
+      expect(() => validateManifestSchema(manifest)).to.not.throw();
+    });
+
     it("validateManifest chainDriver as string", () => {
       const manifest: Manifest = {
         name: "",
@@ -270,7 +302,7 @@ fields:
     title: Graffiti
     maxLength: 32
     description: >-
-      Add a string to your proposed blocks, which will be seen on the block explorer`
+      Add a string to your proposed blocks, which will be seen on the block explorer`;
 
       fs.writeFileSync(setupWizardPath, invalidSetupWizardString);
 

--- a/test/schemaValidation/validateSchema.test.ts
+++ b/test/schemaValidation/validateSchema.test.ts
@@ -18,7 +18,16 @@ describe("schemaValidation", () => {
         description: "",
         type: "dncore",
         license: "1",
-        globalEnvs: ["_first_env", "_second_env"],
+        globalEnvs: [
+          {
+            services: ["web3signer", "ui"],
+            envs: ["_DAPPNODE_GLOBAL_INTERNAL_IP", "_DAPPNODE_GLOBAL_PUBLIC_IP"]
+          },
+          {
+            services: ["db"],
+            envs: ["_DAPPNODE_GLOBAL_PUBKEY"]
+          }
+        ],
         chain: {
           driver: "ethereum"
         }


### PR DESCRIPTION
Allow to define which `globalEnvs` to be injected in the DAppNode package with an array of strings