### PR TITLE
Deprecate `globalEnvs: {all: true}`

### DIFF
--- a/src/schemaValidation/schemas/manifest.schema.json
+++ b/src/schemaValidation/schemas/manifest.schema.json
@@ -151,47 +151,32 @@
       }
     },
     "globalEnvs": {
-      "oneOf": [
-        {
-          "type": "array",
-          "description": "Request the DAPPMANAGER to inject the selected global ENVs to this package's containers",
-          "items": {
-            "type": "object",
-            "properties": {
-              "envs": {
-                "type": "array",
-                "description": "The list of envs to inject to the defined services",
-                "items": {
-                  "type": "string",
-                  "examples": [
-                    "_DAPPNODE_GLOBAL_NO_NAT_LOOPBACK",
-                    "_DAPPNODE_GLOBAL_PUBLIC_IP"
-                  ]
-                },
-                "services": {
-                  "type": "array",
-                  "description": "The services to inject the global ENVs to",
-                  "items": {
-                    "type": "string",
-                    "examples": ["webserver", "backend", "service1"]
-                  }
-                }
+      "type": "array",
+      "description": "Request the DAPPMANAGER to inject the selected global ENVs to this package's containers",
+      "items": {
+        "type": "object",
+        "properties": {
+          "envs": {
+            "type": "array",
+            "description": "The list of envs to inject to the defined services",
+            "items": {
+              "type": "string",
+              "examples": [
+                "_DAPPNODE_GLOBAL_NO_NAT_LOOPBACK",
+                "_DAPPNODE_GLOBAL_PUBLIC_IP"
+              ]
+            },
+            "services": {
+              "type": "array",
+              "description": "The services to inject the global ENVs to",
+              "items": {
+                "type": "string",
+                "examples": ["webserver", "backend", "service1"]
               }
             }
           }
-        },
-        {
-          "type": "object",
-          "description": "Request the DAPPMANAGER to inject global ENVs to this package's containers",
-          "properties": {
-            "all": {
-              "type": "boolean",
-              "description": "Request the DAPPMANAGER to inject all available global ENVs",
-              "examples": ["true"]
-            }
-          }
         }
-      ]
+      }
     },
     "architectures": {
       "type": "array",

--- a/test/schemaValidation/validateSchema.test.ts
+++ b/test/schemaValidation/validateSchema.test.ts
@@ -11,7 +11,7 @@ import { cleanTestDir, testDir } from "../testUtils";
 
 describe("schemaValidation", () => {
   describe("manifest", () => {
-    it("validateManifest globalEnvs as array of strings", () => {
+    it("validateManifest globalEnvs as array of objects", () => {
       const manifest: Manifest = {
         name: "",
         version: "1.0.0",
@@ -28,22 +28,6 @@ describe("schemaValidation", () => {
             envs: ["_DAPPNODE_GLOBAL_PUBKEY"]
           }
         ],
-        chain: {
-          driver: "ethereum"
-        }
-      };
-
-      expect(() => validateManifestSchema(manifest)).to.not.throw();
-    });
-
-    it("validateManifest globalEnvs as object", () => {
-      const manifest: Manifest = {
-        name: "",
-        version: "1.0.0",
-        description: "",
-        type: "dncore",
-        license: "1",
-        globalEnvs: { all: true },
         chain: {
           driver: "ethereum"
         }


### PR DESCRIPTION
Currently there are two ways to inject global environment variables into a dappnode package: 
1. Defining the globalEnv to be injected in a specific service of the dappnode package
2. Injecting all

The second option is not a good approach and looks like an improbable option for a dappnode package to require all the global environment variables

- [x] Deprecate the global Envs feature `{all: true}`
- [ ] Update the sdk dependency in the dappmanager
- [x] Find out all the dappnode packages using this feature and remove this option by the global env required in each case
  - [x] Storj https://github.com/dappnode/DAppNodePackage-storj/issues/85
  - [ ] Near  https://github.com/dappnode/DAppNodePackage-NEAR-testnet/issues/2
  - [x] Pockt  https://github.com/dappnode/DAppNodePackage-pokt/issues/12
- [x] Throw a typed error when `globalEnvs` is an object