### PR TITLE
Persist only staker prater config

### DIFF
--- a/src/commands/githubActions/endToEndTest/ensureDappnodeEnvironment.ts
+++ b/src/commands/githubActions/endToEndTest/ensureDappnodeEnvironment.ts
@@ -52,8 +52,8 @@ async function ensureDockerAliasesResolveFromHost(): Promise<void> {
 async function persistStakerConfigs(
   dappmanagerTestApi: DappmanagerTestApi
 ): Promise<void> {
-  await dappmanagerTestApi.stakerConfigSet(stakerMainnetConfig);
-  await dappmanagerTestApi.stakerConfigSet(stakerGnosisConfig);
+  //await dappmanagerTestApi.stakerConfigSet(stakerMainnetConfig);
+  //await dappmanagerTestApi.stakerConfigSet(stakerGnosisConfig);
   await dappmanagerTestApi.stakerConfigSet(stakerPraterConfig);
 }
 


### PR DESCRIPTION
Persist only staker prater config until more github self host runners are added