### PR TITLE
Do not use aggregated error

### DIFF
--- a/src/commands/githubActions/endToEndTest/executeTests.ts
+++ b/src/commands/githubActions/endToEndTest/executeTests.ts
@@ -86,7 +86,10 @@ export async function executeEndToEndTests({
   }
 
   // Throw aggregated error if any
-  if (errors.length > 0) throw AggregateError(errors);
+  if (errors.length > 0) {
+    const errorMessages = errors.map(e => e.message).join("\n");
+    throw Error(errorMessages);
+  }
 }
 
 function printPackageMetadata(


### PR DESCRIPTION
Do not use aggregated error on end to end test