### PR TITLE
Skip attestation proof if network is mainnet

### DIFF
--- a/src/commands/githubActions/endToEndTest/utils.ts
+++ b/src/commands/githubActions/endToEndTest/utils.ts
@@ -102,6 +102,7 @@ export function getExecuteProofOfAttestation({
   const isExecutionPkg = executionPkgs.includes(dnpName as any);
   if (
     !network ||
+    network === "mainnet" ||
     process.env.TEST ||
     !isStakerPkg ||
     (isExecutionPkg && dnpName !== getDefaultExecClient(network))


### PR DESCRIPTION
Do not execute proof of attestation for network mainnet