### PR TITLE
Fix image tagging monoservice (Breaking chainge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/dappnode/DAppNodeSDK#readme",
   "dependencies": {
     "@dappnode/schemas": "^0.1.6",
-    "@dappnode/types": "^0.1.9",
+    "@dappnode/types": "^0.1.11",
     "@octokit/rest": "^18.0.12",
     "async-retry": "^1.2.3",
     "chalk": "^2.4.2",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -177,6 +177,7 @@ It only covers the most common items, and tries to guess sensible defaults.
   // Construct DNP
   const dnpName = answers.name ? getDnpName(answers.name) : defaultName;
   const serviceName = dnpName;
+  const isMonoService = true;
   const version = answers.version || defaultVersion;
   const manifest: Manifest = {
     name: dnpName,
@@ -196,7 +197,12 @@ It only covers the most common items, and tries to guess sensible defaults.
     services: {
       [serviceName]: {
         build: ".", // Dockerfile is in root dir
-        image: getImageTag({ dnpName, serviceName, version }),
+        image: getImageTag({
+          dnpName,
+          serviceName,
+          version,
+          isMonoService
+        }),
         restart: "unless-stopped"
       }
     }

--- a/src/files/compose/getComposePackageImages.ts
+++ b/src/files/compose/getComposePackageImages.ts
@@ -1,4 +1,4 @@
-import { Compose, getImageTag } from "@dappnode/types";
+import { Compose, getImageTag, getIsMonoService } from "@dappnode/types";
 import { PackageImage } from "../../types.js";
 
 /**
@@ -10,7 +10,12 @@ export function getComposePackageImages(
 ): PackageImage[] {
   return Object.entries(compose.services).map(
     ([serviceName, service]): PackageImage => {
-      const imageTag = getImageTag({ dnpName, serviceName, version });
+      const imageTag = getImageTag({
+        dnpName,
+        serviceName,
+        version,
+        isMonoService: getIsMonoService(compose)
+      });
       return service.build
         ? { type: "local", imageTag }
         : { type: "external", imageTag, originalImageTag: service.image };

--- a/src/files/compose/updateComposeImageTags.ts
+++ b/src/files/compose/updateComposeImageTags.ts
@@ -1,6 +1,6 @@
 import { mapValues } from "lodash-es";
 import { upstreamImageLabel } from "../../params.js";
-import { Compose, getImageTag } from "@dappnode/types";
+import { Compose, getImageTag, getIsMonoService } from "@dappnode/types";
 
 /**
  * Update service image tag to current version
@@ -14,7 +14,12 @@ export function updateComposeImageTags(
   return {
     ...compose,
     services: mapValues(compose.services, (service, serviceName) => {
-      const newImageTag = getImageTag({ dnpName, serviceName, version });
+      const newImageTag = getImageTag({
+        dnpName,
+        serviceName,
+        version,
+        isMonoService: getIsMonoService(compose)
+      });
       return service.build
         ? {
             ...service,

--- a/test/files/compose/updateComposeImageTags.test.ts
+++ b/test/files/compose/updateComposeImageTags.test.ts
@@ -57,7 +57,7 @@ describe("files / compose / updateComposeImageTags", () => {
       const expectedImages: PackageImage[] = [
         {
           type: "local",
-          imageTag: "mypackage.mypackage.public.dappnode.eth:0.1.0"
+          imageTag: "mypackage.public.dappnode.eth:0.1.0"
         }
       ];
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -11,13 +11,14 @@ export function cleanTestDir(): void {
 export function generateCompose(manifest: Manifest): Compose {
   const dnpName = manifest.name,
     serviceName = manifest.name,
-    version = manifest.version;
+    version = manifest.version,
+    isMonoService = true;
   return {
     version: "3.4",
     services: {
       [serviceName]: {
         build: ".", // Dockerfile is in root dir
-        image: getImageTag({ dnpName, serviceName, version }),
+        image: getImageTag({ dnpName, serviceName, version, isMonoService }),
         restart: "unless-stopped"
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,11 @@
     ajv-errors "^3.0.0"
     semver "^7.5.0"
 
+"@dappnode/types@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@dappnode/types/-/types-0.1.11.tgz#ef0d7e30ff1a03691c2f5be7bc6ee422ec4c7ff1"
+  integrity sha512-6n8YU2D0FRBkuG4QGXSbh4iv6xZ6z+oKIkZypznBpT83+hYNbAV9n/1qWwzQ+f4IhKqWTvmMTndwrwlNsOXBTg==
+
 "@dappnode/types@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@dappnode/types/-/types-0.1.9.tgz#23d13181ab077b33e23b929bd32cc6b2b618ec4a"


### PR DESCRIPTION
Fix image tagging mono service (Breaking change), it depends on the same work on dappmanager.

The types library would require a minimum dappnode version injected on every mono service package so the dappmanager can install such package

Depends on:
- [ ] The PR that adds this logic onto the dappmanager https://github.com/dappnode/DNP_DAPPMANAGER/pull/1481
- [ ] Add the minimumDappnodeVersion to all dappnode packages that are mono-service
