### PR TITLE
update ethersjs to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cli-progress": "^3.8.2",
     "dockerode": "^3.3.5",
     "dotenv": "^8.2.0",
-    "ethers": "^5.7.2",
+    "ethers": "^6.3.0",
     "figlet": "^1.2.3",
     "form-data": "^3.0.0",
     "got": "^10.5.5",

--- a/src/tasks/generatePublishTx.ts
+++ b/src/tasks/generatePublishTx.ts
@@ -58,7 +58,7 @@ export function generatePublishTx({
           const repository = await apm.getRepoContract(ensName);
           if (repository) {
             ctx.txData = {
-              to: repository.address,
+              to: await repository.getAddress(),
               value: 0,
               data: encodeNewVersionCall({
                 version: currentVersion,
@@ -81,7 +81,7 @@ export function generatePublishTx({
             // A developer address must be provided by the option -a or --developer_address.
             if (
               !developerAddress ||
-              !ethers.utils.isAddress(developerAddress) ||
+              !ethers.isAddress(developerAddress) ||
               isZeroAddress(developerAddress)
             ) {
               throw new YargsError(
@@ -100,7 +100,7 @@ with command option:
             }
 
             ctx.txData = {
-              to: registry.address,
+              to: await registry.getAddress(),
               value: 0,
               data: encodeNewRepoWithVersionCall({
                 name: shortName,

--- a/src/utils/Apm.ts
+++ b/src/utils/Apm.ts
@@ -28,7 +28,7 @@ function getEthereumProviderUrl(provider = "dappnode"): string {
  * @return apm instance
  */
 export class Apm {
-  provider: ethers.providers.JsonRpcProvider;
+  provider: ethers.JsonRpcProvider;
 
   constructor(providerId: string) {
     // Initialize ens and web3 instances
@@ -36,7 +36,7 @@ export class Apm {
     // This application does not need subscriptions and performs very few requests per use
     const providerUrl = getEthereumProviderUrl(providerId);
 
-    this.provider = new ethers.providers.JsonRpcProvider(providerUrl);
+    this.provider = new ethers.JsonRpcProvider(providerUrl);
   }
 
   // Ens throws if a node is not found
@@ -136,7 +136,7 @@ export function encodeNewVersionCall({
   contractAddress: string;
   contentURI: string;
 }): string {
-  const repo = new ethers.utils.Interface(repoAbi);
+  const repo = ethers.Interface.from(repoAbi)
   return repo.encodeFunctionData("newVersion", [
     semverToArray(version), // uint16[3] _newSemanticVersion
     contractAddress, // address _contractAddress
@@ -166,7 +166,7 @@ export function encodeNewRepoWithVersionCall({
   contractAddress: string;
   contentURI: string;
 }): string {
-  const registry = new ethers.utils.Interface(registryAbi);
+  const registry = ethers.Interface.from(registryAbi)
   return registry.encodeFunctionData("newRepoWithVersion", [
     name, // string _name
     developerAddress, // address _dev

--- a/test/utils/Apm.test.ts
+++ b/test/utils/Apm.test.ts
@@ -12,8 +12,8 @@ describe("Apm constructor", function () {
     const registry = await apm.getRegistryContract(dnpName);
 
     if (!registry) throw Error("no registry");
-    expect(registry.address).to.be.a("string", "Contract instance changed");
-    expect(registry.address.toLowerCase()).to.equal(
+    expect(await registry.getAddress()).to.be.a("string", "Contract instance changed");
+    expect((await registry.getAddress()).toLowerCase()).to.equal(
       "0x266BFdb2124A68beB6769dC887BD655f78778923".toLowerCase()
     );
   });
@@ -23,8 +23,8 @@ describe("Apm constructor", function () {
     const repo = await apm.getRepoContract(dnpName);
 
     if (!repo) throw Error("no repo");
-    expect(repo.address).to.be.a("string", "Contract instance changed");
-    expect(repo.address.toLowerCase()).to.equal(
+    expect(await repo.getAddress()).to.be.a("string", "Contract instance changed");
+    expect((await repo.getAddress()).toLowerCase()).to.equal(
       "0xEe66C4765696C922078e8670aA9E6d4F6fFcc455".toLowerCase()
     );
   });


### PR DESCRIPTION
Since [toolkit](https://github.com/dappnode/toolkit) needs to be implemented in this SDK and uses ethers.js version 6.3.0, updating ethers from 5.X.X to 6.X.X on the SDK was necessary. These changes do not introduce any new functionalities or alter the code's logic; they simply update the ethers.js calls within the code.

At the time of writing this, the ethers.js v6 documentation is far from finished, so some updated calls lack proper documentation, but I have successfully initialized and published a DappNode package using this version of the SDK, and all tests have passed.