### PR TITLE
Update build print url

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ assignees:
 
 **DAppNode version:**
 
-<!--Print the DAppNode versions and info found in http://my.dappnode/#/support/report -->
+<!--Print the DAppNode versions and info found in http://my.dappnode/support/report -->
 
 - Package version: <!-- v0.1.14, upstream: prysm-1.0.0-beta -->
 - OS: <!-- Ubuntu, Debian, DAppNode Mini, DAppNode Advance -->

--- a/src/utils/getLinks.ts
+++ b/src/utils/getLinks.ts
@@ -29,5 +29,5 @@ export function getPublishTxLink(txData: TxData): string {
  * @param releaseMultiHash
  */
 export function getInstallDnpLink(releaseMultiHash: string): string {
-  return `${adminUiBaseUrl}/installer/${encodeURIComponent(releaseMultiHash)}`;
+  return `${adminUiBaseUrl}/installer/public/${encodeURIComponent(releaseMultiHash)}`;
 }


### PR DESCRIPTION
Continuing the work in this PR: https://github.com/dappnode/DAppNodeSDK/commit/028a0569263d5f1c861b17bcc0a1ea8ecf07a233
Update printed URL when building a package. Tested locally.

Before:
![Screenshot_20230823_113739](https://github.com/dappnode/DAppNodeSDK/assets/36164126/95b29ebb-e068-4013-b141-e637bc4fa3c2)

After:
![Screenshot_20230823_113812](https://github.com/dappnode/DAppNodeSDK/assets/36164126/a9bb26b9-ecac-43e5-88a3-0064235b2387)
