### PR TITLE
Avoid failure on bump to non-published pkg

### DIFF
--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -201,10 +201,16 @@ Compose - ${JSON.stringify(compose, null, 2)}
       dir
     });
   } catch (e) {
-    e.message = `Error getting next version from apm: ${e.message}`;
-    e.message += `\nManifest version set to default 0.1.0`;
 
-    manifest.version = "0.1.0";
+    if (e.message.includes("NOREPO")) {
+      console.log("Package not found in APM (probably not published yet");
+      console.log("Manifest version set to default 0.1.0");
+      manifest.version = "0.1.0";
+    } else {
+      e.message = `Error getting next version from apm: ${e.message}`;
+      throw e;
+    }
+
   }
 
   writeManifest(manifest, format, { dir });

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -202,9 +202,9 @@ Compose - ${JSON.stringify(compose, null, 2)}
     });
   } catch (e) {
     e.message = `Error getting next version from apm: ${e.message}`;
-    e.message += `\nManifest version could not be updated`;
+    e.message += `\nManifest version set to default 0.1.0`;
 
-    throw e;
+    manifest.version = "0.1.0";
   }
 
   writeManifest(manifest, format, { dir });


### PR DESCRIPTION
Bump action is failing on packages that have not been published, because the current package version cannot be fetched (`NO_REPO` exception). This error should not prevent the action from being run

![image](https://github.com/dappnode/DAppNodeSDK/assets/47595345/5a46092f-602c-4dd8-bf1e-58c44010079e)
