### PR TITLE
fix: qemu version for cross builds

### DIFF
--- a/src/tasks/buildWithBuildx.ts
+++ b/src/tasks/buildWithBuildx.ts
@@ -51,7 +51,10 @@ export function buildWithBuildx({
         switch (architecture) {
           case "linux/arm64":
             await shell(
-              `docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64`
+              `docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*`
+            );
+            await shell(
+              `docker run --privileged --rm tonistiigi/binfmt --install all`
             );
             // Make sure QEMU is enabled
             // `cat /proc/sys/fs/binfmt_misc/qemu-aarch64`


### PR DESCRIPTION
`libc-bin` caused segfaults on cross compiles with older qemu versions. This PR fixes that by using the new recommended binfmt instead of the deprecated one. Tested and works/fixes issues I had with cross compiles.