### PR TITLE
Debug console instead of throwing an error

### DIFF
--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -130,8 +130,10 @@ Compose - ${JSON.stringify(compose, null, 2)}
     const argName = upstreamArgs[i];
     const newVersion = latestRelease.tag_name;
 
-    if (isUndesiredRealease(newVersion))
-      throw Error(`This is a realease candidate`);
+    if (isUndesiredRealease(newVersion)) {
+      console.log(`This is a realease candidate - ${repoSlug}: ${newVersion}`);
+      return;
+    }
     upstreamRepoVersions.set(argName, { repo, repoSlug, newVersion });
 
     console.log(`Fetch latest version(s) - ${repoSlug}: ${newVersion}`);


### PR DESCRIPTION
When the upstream version is identified as "release candidate" or "nightly" this si debugged in the console to avoid throwing an error.