### PR TITLE
Removing RC check when bumping upstreamVersion release

### DIFF
--- a/src/commands/githubActions/bumpUpstream/format.ts
+++ b/src/commands/githubActions/bumpUpstream/format.ts
@@ -1,5 +1,3 @@
-import semver from "semver";
-
 export interface VersionToUpdate {
   repoSlug: string;
   newVersion: string;
@@ -28,10 +26,4 @@ export function getUpstreamVersionTag(
     : versionsToUpdate
         .map(({ repoSlug, newVersion }) => `${repoSlug}@${newVersion}`)
         .join(", ");
-}
-
-//Checking if the proposed realease is nightly or realeaseCandidate
-export function isUndesiredRealease(version: string): boolean {
-  if (semver.valid(version) && !semver.prerelease(version)) return false;
-  else return true;
 }

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -3,12 +3,7 @@ import { CommandModule } from "yargs";
 import { CliGlobalOptions } from "../../../types.js";
 import { branchNameRoot, defaultDir } from "../../../params.js";
 import { Github } from "../../../providers/github/Github.js";
-import {
-  isUndesiredRealease,
-  getPrBody,
-  getUpstreamVersionTag,
-  VersionToUpdate
-} from "./format.js";
+import { getPrBody, getUpstreamVersionTag, VersionToUpdate } from "./format.js";
 import { shell } from "../../../utils/shell.js";
 import { parseCsv } from "../../../utils/csv.js";
 import { getLocalBranchExists, getGitHead } from "../../../utils/git.js";
@@ -130,10 +125,6 @@ Compose - ${JSON.stringify(compose, null, 2)}
     const argName = upstreamArgs[i];
     const newVersion = latestRelease.tag_name;
 
-    if (isUndesiredRealease(newVersion)) {
-      console.log(`This is a realease candidate - ${repoSlug}: ${newVersion}`);
-      return;
-    }
     upstreamRepoVersions.set(argName, { repo, repoSlug, newVersion });
 
     console.log(`Fetch latest version(s) - ${repoSlug}: ${newVersion}`);

--- a/test/commands/gaBumpUpstream/format.test.ts
+++ b/test/commands/gaBumpUpstream/format.test.ts
@@ -2,7 +2,6 @@ import { expect } from "chai";
 import {
   getPrBody,
   getUpstreamVersionTag,
-  isUndesiredRealease,
   VersionToUpdate
 } from "../../../src/commands/githubActions/bumpUpstream/format.js";
 
@@ -56,52 +55,6 @@ describe("command / gaBumpUpstream / format", () => {
 
 - [sigp/lighthouse](https://github.com/sigp/lighthouse) from v0.1.2 to [v0.1.4](https://github.com/sigp/lighthouse/releases/tag/v0.1.4)
 - [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v0.1.0-beta.28 to [v0.1.0-beta.29](https://github.com/prysmaticlabs/prysm/releases/tag/v0.1.0-beta.29)`);
-    });
-  });
-
-  describe("checkDesiredRealease", () => {
-    const versionsToUpdate: VersionToUpdate[] = [
-      {
-        repoSlug: "sigp/lighthouse",
-        newVersion: "v0.1.5",
-        currentVersion: "v0.1.2"
-      },
-      {
-        repoSlug: "sigp/lighthouse",
-        newVersion: "v0.1.4-rc.0",
-        currentVersion: "v0.1.2"
-      },
-      {
-        repoSlug: "ipfs/kubo",
-        newVersion: "v0.27.0-rc1",
-        currentVersion: "v0.1.2"
-      },
-      {
-        repoSlug: "sigp/lighthouse",
-        newVersion: "v0.1.4-RC.0",
-        currentVersion: "v0.1.2"
-      },
-      {
-        repoSlug: "status-im/nimbus-eth2",
-        newVersion: "nightly",
-        currentVersion: "v23.3.2"
-      }
-    ];
-
-    it("isDesiredRealease", () => {
-      expect(isUndesiredRealease(versionsToUpdate[0].newVersion)).equal(false);
-    });
-    it("isRealeaseCandidate", () => {
-      expect(isUndesiredRealease(versionsToUpdate[1].newVersion)).equal(true);
-    });
-    it("isRealeaseCandidate", () => {
-      expect(isUndesiredRealease(versionsToUpdate[2].newVersion)).equal(true);
-    });
-    it("isRealeaseCandidate", () => {
-      expect(isUndesiredRealease(versionsToUpdate[3].newVersion)).equal(true);
-    });
-    it("isNightlyRealease", () => {
-      expect(isUndesiredRealease(versionsToUpdate[4].newVersion)).equal(true);
     });
   });
 });


### PR DESCRIPTION
When bumping new version of a release, removing the function that blocks "release candidates" or "nightly" versions to be proposed