### PR TITLE
Bump js-yaml to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "graphql": "^16.6.0",
     "image-size": "^0.8.1",
     "inquirer": "^6.2.1",
-    "js-yaml": "^3.12.1",
+    "js-yaml": "^4.1.0",
     "listr": "^0.14.3",
     "lodash-es": "^4.17.21",
     "mime-types": "^2.1.24",

--- a/src/files/compose/readCompose.ts
+++ b/src/files/compose/readCompose.ts
@@ -14,7 +14,7 @@ export function readCompose(paths?: ComposePaths): Compose {
 
   // Parse compose in try catch block to show a comprehensive error message
   try {
-    const compose = yaml.safeLoad(data);
+    const compose = yaml.load(data);
     if (!compose) throw Error("result is undefined");
     if (typeof compose === "string") throw Error("result is a string");
     return compose as Compose;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2571,13 +2571,20 @@ js-yaml@4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.12.1, js-yaml@^3.13.1:
+js-yaml@^3.13.1:
   version "3.14.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Bump `js-yaml` to 4.1.0 as this latest library version makes `yaml.load(...)` function safe by default, so that `safeLoad` is no longer needed 