### PR TITLE
Support new upstream format

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@dappnode/schemas": "^0.1.16",
     "@dappnode/toolkit": "^0.1.21",
-    "@dappnode/types": "^0.1.34",
+    "@dappnode/types": "^0.1.36",
     "@octokit/rest": "^18.0.12",
     "async-retry": "^1.2.3",
     "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "homepage": "https://github.com/dappnode/DAppNodeSDK#readme",
   "dependencies": {
-    "@dappnode/schemas": "^0.1.16",
+    "@dappnode/schemas": "^0.1.18",
     "@dappnode/toolkit": "^0.1.21",
-    "@dappnode/types": "^0.1.36",
+    "@dappnode/types": "^0.1.37",
     "@octokit/rest": "^18.0.12",
     "async-retry": "^1.2.3",
     "chalk": "^2.4.2",

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -104,7 +104,7 @@ async function getUpstreamRepoVersions(upstreamSettings: UpstreamSettings[]): Pr
   const upstreamRepoVersions: UpstreamRepoMap = {};
 
   try {
-    for (const { upstreamArg, upstreamRepo } of upstreamSettings) {
+    for (const { arg: upstreamArg, repo: upstreamRepo } of upstreamSettings) {
 
       const [owner, repo] = upstreamRepo.split("/");
       const githubRepo = new Github({ owner, repo });

--- a/src/commands/githubActions/bumpUpstream/settings/getInitialSettings.ts
+++ b/src/commands/githubActions/bumpUpstream/settings/getInitialSettings.ts
@@ -31,6 +31,10 @@ export async function getInitialSettings({ dir, userEthProvider, useFallback }: 
     };
 }
 
+/**
+ * Supports both legacy 'upstreamRepo' and 'upstreamArg' fields and current 'upstream' 
+ * field (array of objects with 'repo', 'arg' and 'version' fields)
+ */
 function parseUpstreamSettings(manifest: Manifest): UpstreamSettings[] {
 
     const upstreamSettings =
@@ -46,8 +50,6 @@ function parseUpstreamSettings(manifest: Manifest): UpstreamSettings[] {
 /**
  * Legacy support for 'upstreamRepo' and 'upstreamArg' fields
  * Currently, 'upstream' field is used instead, which is an array of objects with 'repo', 'arg' and 'version' fields
- * @param manifest 
- * @returns 
  */
 function parseUpstreamSettingsFromLegacy(manifest: Manifest): UpstreamSettings[] {
     const upstreamRepos = parseCsv(manifest.upstreamRepo);

--- a/src/commands/githubActions/bumpUpstream/types.ts
+++ b/src/commands/githubActions/bumpUpstream/types.ts
@@ -3,8 +3,8 @@ import { ManifestFormat } from "../../../files/manifest/types.js";
 import { Github } from "../../../providers/github/Github.js";
 
 export interface UpstreamSettings {
-    upstreamRepo: string;
-    upstreamArg: string;
+    repo: string;
+    arg: string;
 }
 
 export interface GitSettings {

--- a/src/pinStrategy/index.ts
+++ b/src/pinStrategy/index.ts
@@ -17,12 +17,17 @@ export function getPinMetadata(
   manifest: Manifest,
   gitHead?: GitHead
 ): PinataMetadata<DnpPinMetadata> {
+
+  const upstreamVersion = Array.isArray(manifest.upstreamVersion) ?
+    manifest.upstreamVersion.join(", ") :
+    manifest.upstreamVersion;
+
   return {
     name: prettyPinataPinName(manifest, gitHead),
     keyvalues: {
       dnpName: manifest.name,
       version: manifest.version,
-      upstreamVersion: manifest.upstreamVersion,
+      upstreamVersion: upstreamVersion,
       commit: gitHead ? gitHead.commit : undefined,
       branch: gitHead ? gitHead.branch : undefined
     }

--- a/src/pinStrategy/types.ts
+++ b/src/pinStrategy/types.ts
@@ -4,7 +4,7 @@
 export interface DnpPinMetadata {
   dnpName: string;
   version: string;
-  upstreamVersion: string | undefined;
+  upstreamVersion: string | undefined | string[];
   commit: string | undefined;
   branch: string | undefined;
 }

--- a/src/releaseUploader/pinata/PinataSDK.ts
+++ b/src/releaseUploader/pinata/PinataSDK.ts
@@ -1,5 +1,5 @@
 export type PinKeyvaluesDefault = {
-  [key: string]: string | number | undefined | string[];
+  [key: string]: string | number | undefined;
 };
 
 export interface PinataMetadata<PinKeyvalues = PinKeyvaluesDefault> {

--- a/src/releaseUploader/pinata/PinataSDK.ts
+++ b/src/releaseUploader/pinata/PinataSDK.ts
@@ -1,5 +1,5 @@
 export type PinKeyvaluesDefault = {
-  [key: string]: string | number | undefined;
+  [key: string]: string | number | undefined | string[];
 };
 
 export interface PinataMetadata<PinKeyvalues = PinKeyvaluesDefault> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,12 +57,12 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@dappnode/schemas@^0.1.16":
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/@dappnode/schemas/-/schemas-0.1.16.tgz#9cef9749fe7d9baf823e0f9c992dd1e807b2a5db"
-  integrity sha512-we+BJKXHPW/8hNp/xSPrgjXnrK+4dRpYupFJh4hiUFWuaTeJLOmWgcCNzvly151H2RkAQSLqBsOFj4Pt/Vtysg==
+"@dappnode/schemas@^0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@dappnode/schemas/-/schemas-0.1.18.tgz#2d937bdcaebf446e5fe4e42af904be90d9e472a7"
+  integrity sha512-Pxahr4u72yiPVZDVDMXHEQWRuW22nOUuBtY5N3+XGL6qeZZNXNxkzlnP4mEUGBqUBBizK6ffWCCj1OZ/N8XddQ==
   dependencies:
-    "@dappnode/types" "^0.1.36"
+    "@dappnode/types" "^0.1.37"
     ajv "^8.12.0"
     semver "^7.5.0"
 
@@ -89,10 +89,10 @@
   resolved "https://registry.yarnpkg.com/@dappnode/types/-/types-0.1.34.tgz#f84713687860b569e405884132a953e4ee4b8ade"
   integrity sha512-07DEQVP6umDUDhDcX8m7EZMZtUUeyOeigupTWo8/oNsHuw7/V+UMCnUjYr1UsoNug2B3nRJ4V+iYQl0R/fhBEQ==
 
-"@dappnode/types@^0.1.36":
-  version "0.1.36"
-  resolved "https://registry.yarnpkg.com/@dappnode/types/-/types-0.1.36.tgz#caa45a9290c10feb77e954a00119ec91cd9c8bc1"
-  integrity sha512-gUaHrOZKDoyHvZcyMu0IviKCikvHLrcl6pRWFFxlJgGlV5ZGaHBc7U6r6DZqZmj9bpebkpdSLRQBDVx6QA5t6Q==
+"@dappnode/types@^0.1.37":
+  version "0.1.37"
+  resolved "https://registry.yarnpkg.com/@dappnode/types/-/types-0.1.37.tgz#c66424ca047006cb3b7e22e8d38556babc692bd6"
+  integrity sha512-+MBKIQsiMG78Yt8mAqQJXDih1D1IqiQVQdXHAdJfoBONnd+bl1shPuOggvS53iBQ54yq1Ccc5oI7usV4a04g0w==
 
 "@graphql-typed-document-node/core@^3.2.0":
   version "3.2.0"


### PR DESCRIPTION
Upstream sofware was previously defined like: `upstreamRepo`, `upstreamVersion` and `upstreamArg` in the manifest. They could receive a string or an array, so this has been migrated to a new format, defined in https://github.com/dappnode/DAppNodeSDK/issues/408

This PR will support both formats for the bump-upstream action