### PR TITLE
Set latest SDK published version to 0.3.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dappnode/dappnodesdk",
-  "version": "0.3.24",
+  "version": "0.3.20",
   "type": "module",
   "description": "dappnodesdk is a tool to make the creation of new dappnode packages as simple as possible. It helps to initialize and publish in ethereum blockchain",
   "main": "dist/index.js",


### PR DESCRIPTION
After failing to publish SDK to npm (due to a wrong version of `actions/create-release` fixed in https://github.com/dappnode/DAppNodeSDK/pull/423) the manifest version has been set to a wrong value