### PR TITLE
Allow non-semver releases

### DIFF
--- a/src/commands/githubActions/bumpUpstream/github/isValidRelease.ts
+++ b/src/commands/githubActions/bumpUpstream/github/isValidRelease.ts
@@ -4,10 +4,16 @@ export function isValidRelease(version: string): boolean {
   // Nightly builds are not considered valid releases (not taken into account by semver)
   if (version.includes("nightly")) return false;
 
-  if (!semver.valid(version)) return false;
+  if (semver.valid(version)) {
+    const preReleases = semver.prerelease(version);
 
-  const preReleases = semver.prerelease(version);
+    // A version is considered a valid release if it has no pre-release components.
+    return preReleases === null || preReleases.length === 0;
+  }
 
-  // A version is considered a valid release if it has no pre-release components.
-  return preReleases === null || preReleases.length === 0;
+  console.warn(
+    `Upstream version (${version}) does not follow semver. This might be a release candidate or pre-release.`
+  );
+
+  return true;
 }


### PR DESCRIPTION
Allowing non-semver releases for bump action. The previous approach would make the action fail for repos like https://github.com/dappnode/DAppNodePackage-monero, whose upstream repo is https://github.com/monero-project/monero, which includes release tags that do not follow semver. Instead, they look like: `v0.18.3.3`

Example: https://github.com/dappnode/DAppNodePackage-monero/actions/runs/9059682266/job/24887782261#step:3:17