### PR TITLE
Fix build for new upstream format

### DIFF
--- a/src/providers/github/Github.ts
+++ b/src/providers/github/Github.ts
@@ -54,7 +54,7 @@ export class Github {
       });
     } catch (e) {
       const repoSlug = `${this.owner}/${this.repo}`;
-      if (e.status === 404) throw Error(`Repo does not exist: ${repoSlug}`);
+      if (e.status === "404") throw Error(`Repo does not exist: ${repoSlug}`);
       e.message = `Error verifying repo ${repoSlug}: ${e.message}`;
       throw e;
     }
@@ -361,7 +361,7 @@ export class Github {
       const data = await this.getBranch(branch);
       return Boolean(data);
     } catch (e) {
-      if (e.status === 404) return false;
+      if (e.status === "404") return false;
       else throw e;
     }
   }

--- a/src/tasks/buildAndUpload/buildVariantMap.ts
+++ b/src/tasks/buildAndUpload/buildVariantMap.ts
@@ -66,8 +66,11 @@ export function createVariantMapEntry({
       ])
     : readCompose([{ dir: rootDir, composeFileName }]);
 
-  const upstreamVersion = getUpstreamVersion({ compose, manifest });
-  manifest.upstreamVersion = upstreamVersion;
+  // Only parse this upstream version for legacy format (upstreamVersion field defined instead of upstream object)
+  if (!manifest.upstream) {
+    const upstreamVersion = getUpstreamVersion({ compose, manifest });
+    manifest.upstreamVersion = upstreamVersion;
+  }
 
   return {
     manifest,

--- a/test/commands/build.test.ts
+++ b/test/commands/build.test.ts
@@ -8,8 +8,9 @@ import {
   defaultVariantsDirName,
   defaultVariantsEnvValues
 } from "../../src/params.js";
+import { normalizeIpfsProvider } from "../../src/releaseUploader/ipfsNode/ipfsProvider.js";
 
-const contentProvider = "http://api.ipfs.dappnode.io:5001";
+const contentProvider = normalizeIpfsProvider("remote");
 
 // This test will create the following fake files
 // ./dappnode_package.json  => fake manifest


### PR DESCRIPTION
Building packages that include the new upstream format in their manifest (https://github.com/dappnode/DAppNodePackage-holesky-obol/blob/374c1d0d6aebbbf38d96d53804e5de1b401d3f65/dappnode_package.json#L4) fail with this error:

https://github.com/dappnode/DAppNodePackage-DMS/actions/runs/9514324171/job/26226282057#step:3:25

This PR fixes it