### PR TITLE
Enable variants on github action build

### DIFF
--- a/src/commands/githubActions/build/botComment.ts
+++ b/src/commands/githubActions/build/botComment.ts
@@ -21,7 +21,7 @@ export function getBuildBotComment({
   const buildEntries = Object.entries(buildResults)
     .map(([dnpName, { releaseMultiHash }], index) => {
       if (releaseMultiHash)
-        formatBuildEntry({ dnpName, releaseMultiHash, index });
+        return formatBuildEntry({ dnpName, releaseMultiHash, index });
     })
     .join("\n\n");
 

--- a/src/commands/githubActions/build/types.ts
+++ b/src/commands/githubActions/build/types.ts
@@ -1,0 +1,6 @@
+import { CliGlobalOptions } from "../../../types.js";
+
+export interface BuildActionOptions extends CliGlobalOptions {
+    variants?: string;
+    all_variants?: boolean;
+}

--- a/src/commands/githubActions/bumpUpstream/index.ts
+++ b/src/commands/githubActions/bumpUpstream/index.ts
@@ -56,6 +56,7 @@ export const gaBumpUpstream: CommandModule<
       type: "boolean"
     },
     use_variants: {
+      alias: "use-variants",
       description: `It will use the dappnode_package.json and docker-compose.yml files in the root of the project together with the specific ones defined for each package variant to build all of them`,
       type: "boolean"
     },
@@ -233,8 +234,8 @@ async function updateManifestPkgVersion({
 }): Promise<void> {
   const manifestDirs = allVariants
     ? getAllVariantsInPath(variantsDir).map(variant =>
-        path.join(variantsDir, variant)
-      )
+      path.join(variantsDir, variant)
+    )
     : [dir];
 
   for (const dir of manifestDirs) {


### PR DESCRIPTION
Github Action build was omitting flags `variants` and `all-variants`, so it would not build multi-variant packages. This PR enables it

Furthermore, this PR aims to solve an existing issue, explained below:

Bot comment after github action build did not include the built hash, as shown here: https://github.com/dappnode/DNP_HTTPS/pull/94#issuecomment-2220296545