### PR TITLE
Fix docker image not found error

### DIFF
--- a/src/tasks/publish/subtasks/getUpdateFilesTask.ts
+++ b/src/tasks/publish/subtasks/getUpdateFilesTask.ts
@@ -6,7 +6,8 @@ import {
   readCompose,
   updateComposeImageTags,
   writeCompose,
-  readManifest
+  readManifest,
+  getComposePackageImages
 } from "../../../files/index.js";
 
 export function getUpdateFilesTask({
@@ -44,9 +45,13 @@ export function getUpdateFilesTask({
           isMultiVariant
         });
 
+        const newCompose = readCompose(composePaths);
+        const newManifest = readManifest(manifestPaths).manifest;
+
         // Update variantsMap entry
-        variantsMap[variant].compose = readCompose(composePaths);
-        variantsMap[variant].manifest = readManifest(manifestPaths).manifest;
+        variantsMap[variant].compose = newCompose;
+        variantsMap[variant].manifest = newManifest;
+        variantsMap[variant].images = getComposePackageImages(newCompose, newManifest);
       }
     }
   };


### PR DESCRIPTION
Updating the package version in both the compose and manifest files without updating the `images` property of the `variantsMap` would cause the following error to be thrown:
![image](https://github.com/user-attachments/assets/86a29107-453e-4844-bcea-5b9bda788324)