### PR TITLE
Move from variant map to array (rebased)

### DIFF
--- a/src/commands/build/handler.ts
+++ b/src/commands/build/handler.ts
@@ -45,7 +45,7 @@ export async function buildHandler({
     variantsDirPath,
     packagesToBuildProps: getPackagesToBuildProps({
       allVariants: Boolean(allVariants),
-      variantsStr: variants,
+      commaSeparatedVariants: variants,
       rootDir: dir,
       variantsDirPath,
       composeFileName

--- a/src/commands/build/handler.ts
+++ b/src/commands/build/handler.ts
@@ -7,8 +7,9 @@ import {
   defaultVariantsDirName
 } from "../../params.js";
 import { BuildCommandOptions, VerbosityOptions } from "./types.js";
-import { getVariantOptions } from "./variants.js";
+import { getPackagesToBuildProps } from "./variants.js";
 import { BuildAndUploadOptions } from "../../tasks/buildAndUpload/types.js";
+import path from "path";
 
 export async function buildHandler({
   provider: contentProvider,
@@ -29,6 +30,8 @@ export async function buildHandler({
 }: BuildCommandOptions): Promise<ListrContextBuild> {
   const skipUpload = skip_upload || skipSave;
 
+  const variantsDirPath = path.join(dir, variantsDirName);
+
   const buildOptions: BuildAndUploadOptions = {
     dir,
     contentProvider,
@@ -39,11 +42,12 @@ export async function buildHandler({
     composeFileName,
     requireGitData,
     deleteOldPins,
-    ...getVariantOptions({
+    variantsDirPath,
+    packagesToBuildProps: getPackagesToBuildProps({
       allVariants: Boolean(allVariants),
       variantsStr: variants,
       rootDir: dir,
-      variantsDirName,
+      variantsDirPath,
       composeFileName
     })
   };

--- a/src/commands/build/variants.ts
+++ b/src/commands/build/variants.ts
@@ -1,31 +1,26 @@
 import chalk from "chalk";
 import { getAllVariantsInPath } from "../../files/variants/getAllPackageVariants.js";
-import path from "path";
-import { BuildVariantsMap } from "../../types.js";
-import { buildVariantMap } from "../../tasks/buildAndUpload/buildVariantMap.js";
+import { PackageToBuildProps } from "../../types.js";
+import { generatePackagesProps } from "../../tasks/buildAndUpload/generatePackagesProps.js";
 
-export function getVariantOptions({
+export function getPackagesToBuildProps({
   allVariants,
   variantsStr,
   rootDir,
-  variantsDirName,
+  variantsDirPath,
   composeFileName
 }: {
   allVariants: boolean;
   variantsStr?: string;
   rootDir: string;
-  variantsDirName: string;
+  variantsDirPath: string;
   composeFileName: string;
-}): { variantsMap: BuildVariantsMap; variantsDirPath: string } {
-  const variantsDirPath = path.join(rootDir, variantsDirName);
+}): PackageToBuildProps[] {
 
   const buildVariantMapArgs = { rootDir, variantsDirPath, composeFileName };
 
   if (!allVariants && !variantsStr)
-    return {
-      variantsMap: buildVariantMap({ ...buildVariantMapArgs, variants: null }),
-      variantsDirPath
-    };
+    return generatePackagesProps({ ...buildVariantMapArgs, variants: null });
 
   const validVariantNames = getValidVariantNames({
     variantsDirPath,
@@ -43,13 +38,10 @@ export function getVariantOptions({
     )}`
   );
 
-  return {
-    variantsMap: buildVariantMap({
-      ...buildVariantMapArgs,
-      variants: validVariantNames
-    }),
-    variantsDirPath
-  };
+  return generatePackagesProps({
+    ...buildVariantMapArgs,
+    variants: validVariantNames
+  });
 }
 
 /**

--- a/src/commands/build/variants.ts
+++ b/src/commands/build/variants.ts
@@ -5,13 +5,13 @@ import { generatePackagesProps } from "../../tasks/buildAndUpload/generatePackag
 
 export function getPackagesToBuildProps({
   allVariants,
-  variantsStr,
+  commaSeparatedVariants,
   rootDir,
   variantsDirPath,
   composeFileName
 }: {
   allVariants: boolean;
-  variantsStr?: string;
+  commaSeparatedVariants?: string;
   rootDir: string;
   variantsDirPath: string;
   composeFileName: string;
@@ -19,12 +19,12 @@ export function getPackagesToBuildProps({
 
   const buildVariantMapArgs = { rootDir, variantsDirPath, composeFileName };
 
-  if (!allVariants && !variantsStr)
+  if (!allVariants && !commaSeparatedVariants)
     return generatePackagesProps({ ...buildVariantMapArgs, variants: null });
 
   const validVariantNames = getValidVariantNames({
     variantsDirPath,
-    variants: variantsStr
+    variants: commaSeparatedVariants
   });
 
   if (validVariantNames.length === 0)
@@ -34,7 +34,7 @@ export function getPackagesToBuildProps({
 
   console.log(
     `${chalk.dim(
-      `Building package from template for variant(s) ${variantsStr}...`
+      `Building package from template for variant(s) ${commaSeparatedVariants}...`
     )}`
   );
 

--- a/src/commands/publish/handler.ts
+++ b/src/commands/publish/handler.ts
@@ -1,4 +1,5 @@
 import Listr from "listr";
+import path from "path";
 import {
   defaultComposeFileName,
   defaultDir,
@@ -9,7 +10,7 @@ import { VerbosityOptions } from "../build/types.js";
 import { PublishCommandOptions } from "./types.js";
 import { publish } from "../../tasks/publish/index.js";
 import { parseReleaseType } from "./parseReleaseType.js";
-import { getVariantOptions } from "../build/variants.js";
+import { getPackagesToBuildProps } from "../build/variants.js";
 
 /**
  * Common handler for CLI and programatic usage
@@ -37,7 +38,6 @@ export async function publishHandler({
 }: PublishCommandOptions): Promise<ListrContextPublish> {
   let ethProvider = provider || eth_provider;
   let contentProvider = provider || content_provider;
-  const isMultiVariant = Boolean(allVariants) || Boolean(variants);
 
   const isCi = process.env.CI;
 
@@ -61,6 +61,8 @@ export async function publishHandler({
 
   const releaseType = parseReleaseType({ type });
 
+  const variantsDirPath = path.join(dir, variantsDirName);
+
   const publishTasks = new Listr(
     publish({
       releaseType,
@@ -75,14 +77,14 @@ export async function publishHandler({
       developerAddress,
       githubRelease,
       verbosityOptions,
-      ...getVariantOptions({
+      variantsDirPath,
+      packagesToBuildProps: getPackagesToBuildProps({
         allVariants: Boolean(allVariants),
         variantsStr: variants,
         rootDir: dir,
-        variantsDirName,
+        variantsDirPath,
         composeFileName
-      }),
-      isMultiVariant
+      })
     }),
     verbosityOptions
   );

--- a/src/commands/publish/handler.ts
+++ b/src/commands/publish/handler.ts
@@ -80,7 +80,7 @@ export async function publishHandler({
       variantsDirPath,
       packagesToBuildProps: getPackagesToBuildProps({
         allVariants: Boolean(allVariants),
-        variantsStr: variants,
+        commaSeparatedVariants: variants,
         rootDir: dir,
         variantsDirPath,
         composeFileName

--- a/src/params.ts
+++ b/src/params.ts
@@ -14,7 +14,6 @@ export const branchNameRoot = "dappnodebot/bump-upstream/";
 
 export const defaultDir = "./";
 export const defaultVariantsDirName = "package_variants";
-export const singleVariantName = "single-variant";
 // This is the default name of the environment variable that will be used to select each of the variants
 export const defaultVariantsEnvName = "NETWORK";
 export const defaultVariantsEnvValues = ["mainnet", "testnet"];

--- a/src/tasks/buildAndUpload/generatePackagesProps.ts
+++ b/src/tasks/buildAndUpload/generatePackagesProps.ts
@@ -7,10 +7,10 @@ import {
   readManifest
 } from "../../files/index.js";
 import { Compose, Manifest } from "@dappnode/types";
-import { defaultComposeFileName, singleVariantName } from "../../params.js";
-import { BuildVariantsMap, BuildVariantsMapEntry } from "../../types.js";
+import { defaultComposeFileName } from "../../params.js";
+import { PackageToBuildProps } from "../../types.js";
 
-export function buildVariantMap({
+export function generatePackagesProps({
   variants,
   rootDir,
   variantsDirPath,
@@ -20,37 +20,37 @@ export function buildVariantMap({
   rootDir: string;
   variantsDirPath: string;
   composeFileName?: string;
-}): BuildVariantsMap {
-  if (!variants || variants.length === 0)
-    return { [singleVariantName]: createVariantMapEntry({ rootDir, composeFileName }) };
+}): PackageToBuildProps[] {
+  if (variants === null)
+    return [createPackagePropsItem({ rootDir, composeFileName, variant: null, variantsDirPath })];
 
-  const map: BuildVariantsMap = {};
-
-  for (const variant of variants) {
-    const variantPath = path.join(variantsDirPath, variant);
-    map[variant] = createVariantMapEntry({
+  return variants.map((variant) =>
+    createPackagePropsItem({
       rootDir,
       composeFileName,
-      variantPath
-    });
-  }
-
-  return map;
+      variant,
+      variantsDirPath
+    })
+  );
 }
 
-export function createVariantMapEntry({
+function createPackagePropsItem({
   rootDir,
   composeFileName,
-  variantPath
+  variant,
+  variantsDirPath
 }: {
   rootDir: string;
   composeFileName: string;
-  variantPath?: string;
-}): BuildVariantsMapEntry {
+  variant: string | null;
+  variantsDirPath: string;
+}): PackageToBuildProps {
   const manifestPaths = [{ dir: rootDir }];
   const composePaths = [{ dir: rootDir, composeFileName }];
 
-  if (variantPath) {
+  if (variant) {
+    const variantPath = path.join(variantsDirPath, variant);
+
     manifestPaths.push({ dir: variantPath });
     composePaths.push({ dir: variantPath, composeFileName });
   }
@@ -65,6 +65,8 @@ export function createVariantMapEntry({
     manifest.upstreamVersion = getUpstreamVersion({ compose, manifest });
 
   return {
+    variant,
+
     manifest,
     manifestFormat,
 

--- a/src/tasks/buildAndUpload/getDeleteOldPinsTask.ts
+++ b/src/tasks/buildAndUpload/getDeleteOldPinsTask.ts
@@ -1,16 +1,16 @@
 import { ListrTask } from "listr/index.js";
-import { BuildVariantsMap, ListrContextBuild } from "../../types.js";
+import { PackageToBuildProps, ListrContextBuild } from "../../types.js";
 import { getGitHead } from "../../utils/git.js";
 import { fetchPinsWithBranchToDelete } from "../../pinStrategy/index.js";
 import { PinataPinManager } from "../../providers/pinata/pinManager.js";
 import { ReleaseUploaderProvider } from "../../releaseUploader/index.js";
 
 export function getDeleteOldPinsTask({
-  variantsMap,
+  packagesToBuildProps,
   deleteOldPins,
   releaseUploaderProvider
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
   deleteOldPins: boolean;
   releaseUploaderProvider: ReleaseUploaderProvider;
 }): ListrTask<ListrContextBuild> {
@@ -25,7 +25,7 @@ export function getDeleteOldPinsTask({
       // Unpin items on the same branch but previous (ancestor) commits
       const pinata = new PinataPinManager(releaseUploaderProvider);
 
-      for (const [, { manifest }] of Object.entries(variantsMap)) {
+      for (const { manifest } of packagesToBuildProps) {
         const pinsToDelete = await fetchPinsWithBranchToDelete(
           pinata,
           manifest,

--- a/src/tasks/buildAndUpload/getFileCopyTask.ts
+++ b/src/tasks/buildAndUpload/getFileCopyTask.ts
@@ -7,7 +7,7 @@ import {
   defaultComposeFileName,
   releaseFilesDefaultNames
 } from "../../params.js";
-import { BuildVariantsMap, BuildVariantsMapEntry, ListrContextBuild } from "../../types.js";
+import { PackageToBuildProps, ListrContextBuild } from "../../types.js";
 import { getGitHeadIfAvailable } from "../../utils/git.js";
 import {
   updateComposeImageTags,
@@ -17,13 +17,13 @@ import {
 import { Compose, Manifest, releaseFiles } from "@dappnode/types";
 
 export function getFileCopyTask({
-  variantsMap,
+  packagesToBuildProps,
   variantsDirPath,
   rootDir,
   composeFileName,
   requireGitData
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
   variantsDirPath: string;
   rootDir: string;
   composeFileName: string;
@@ -33,7 +33,7 @@ export function getFileCopyTask({
     title: "Copy files to release directory",
     task: async () =>
       copyFilesToReleaseDir({
-        variantsMap,
+        packagesToBuildProps,
         variantsDirPath,
         rootDir,
         composeFileName,
@@ -43,22 +43,21 @@ export function getFileCopyTask({
 }
 
 async function copyFilesToReleaseDir({
-  variantsMap,
+  packagesToBuildProps,
   variantsDirPath,
   rootDir,
   composeFileName,
   requireGitData
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
   variantsDirPath: string;
   rootDir: string;
   composeFileName: string;
   requireGitData?: boolean;
 }): Promise<void> {
-  for (const [variantName, variantProps] of Object.entries(variantsMap)) {
+  for (const variantProps of packagesToBuildProps) {
 
-    const variantDirPath = path.join(variantsDirPath, variantName);
-    await copyVariantFilesToReleaseDir({ variantProps, variantDirPath: variantDirPath, rootDir, composeFileName });
+    await copyVariantFilesToReleaseDir({ variantProps, rootDir, variantsDirPath, composeFileName });
 
     // Verify avatar (throws)
     const avatarPath = path.join(
@@ -74,16 +73,19 @@ async function copyFilesToReleaseDir({
 
 async function copyVariantFilesToReleaseDir({
   variantProps,
-  variantDirPath,
   rootDir,
+  variantsDirPath,
   composeFileName
 }: {
-  variantProps: BuildVariantsMapEntry;
-  variantDirPath: string;
+  variantProps: PackageToBuildProps;
   rootDir: string;
+  variantsDirPath: string;
   composeFileName: string;
 }): Promise<void> {
-  const { manifest, manifestFormat, releaseDir, compose } = variantProps;
+  const { manifest, manifestFormat, releaseDir, compose, variant } = variantProps;
+
+  // In case of single variant packages, the targets are in the root dir
+  const variantDirPath = variant ? path.join(variantsDirPath, variant) : rootDir;
 
   for (const [fileId, fileConfig] of Object.entries(releaseFiles)) {
     // For single variant packages, the targets are in the root dir

--- a/src/tasks/buildAndUpload/getFileValidationTask.ts
+++ b/src/tasks/buildAndUpload/getFileValidationTask.ts
@@ -1,5 +1,5 @@
 import { ListrTask } from "listr/index.js";
-import { BuildVariantsMap, BuildVariantsMapEntry, ListrContextBuild } from "../../types.js";
+import { PackageToBuildProps, ListrContextBuild } from "../../types.js";
 import {
   validateComposeSchema,
   validateManifestSchema,
@@ -10,37 +10,37 @@ import { getComposePath, readSetupWizardIfExists } from "../../files/index.js";
 import { CliError } from "../../params.js";
 
 export function getFileValidationTask({
-  variantsMap,
+  packagesToBuildProps,
   rootDir
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
   rootDir: string;
 }): ListrTask<ListrContextBuild> {
   return {
     title: `Validate files`,
-    task: async () => await validatePackageFiles({ variantsMap, rootDir })
+    task: async () => await validatePackageFiles({ packagesToBuildProps, rootDir })
   };
 }
 
 async function validatePackageFiles({
-  variantsMap,
+  packagesToBuildProps,
   rootDir
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
   rootDir: string;
 }): Promise<void> {
   const setupWizard = readSetupWizardIfExists(rootDir);
 
   if (setupWizard) validateSetupWizardSchema(setupWizard);
 
-  for (const [, variant] of Object.entries(variantsMap))
-    await validateVariantFiles(variant);
+  for (const pkgProps of packagesToBuildProps)
+    await validateVariantFiles(pkgProps);
 }
 
 async function validateVariantFiles(
-  variant: BuildVariantsMapEntry
+  pkgProps: PackageToBuildProps
 ): Promise<void> {
-  const { manifest, compose, composePaths } = variant;
+  const { manifest, compose, composePaths } = pkgProps;
 
   console.log(
     `Validating files for ${manifest.name} (version ${manifest.version})`

--- a/src/tasks/buildAndUpload/getReleaseDirCreationTask.ts
+++ b/src/tasks/buildAndUpload/getReleaseDirCreationTask.ts
@@ -2,35 +2,33 @@ import fs from "fs";
 import path from "path";
 import { ListrTask } from "listr/index.js";
 import rimraf from "rimraf";
-import { BuildVariantsMap, ListrContextBuild } from "../../types.js";
+import { PackageToBuildProps, ListrContextBuild } from "../../types.js";
 import { getImageFileName } from "../../utils/getImageFileName.js";
 
 export function getReleaseDirCreationTask({
-  variantsMap
+  packagesToBuildProps
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
 }): ListrTask<ListrContextBuild> {
   return {
     title: `Create release directories`,
-    task: ctx => createReleaseDirs({ ctx, variantsMap })
+    task: ctx => createReleaseDirs({ ctx, packagesToBuildProps })
   };
 }
 
 function createReleaseDirs({
   ctx,
-  variantsMap
+  packagesToBuildProps
 }: {
   ctx: ListrContextBuild;
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
 }): void {
-  for (const [
+  for (const {
     variant,
-    {
-      manifest: { name, version },
-      releaseDir,
-      architectures
-    }
-  ] of Object.entries(variantsMap)) {
+    manifest: { name, version },
+    releaseDir,
+    architectures
+  } of packagesToBuildProps) {
     console.log(
       `Creating release directory for ${name} (version ${version}) at ${releaseDir}`
     );
@@ -38,8 +36,7 @@ function createReleaseDirs({
     fs.mkdirSync(releaseDir, { recursive: true }); // Ok on existing dir
     const releaseFiles = fs.readdirSync(releaseDir);
 
-    ctx[name] = ctx[name] || { variant };
-    ctx[name].releaseDir = releaseDir;
+    ctx[name] = { variant, releaseDir };
 
     const imagePaths = architectures.map(arch =>
       getImageFileName(name, version, arch)

--- a/src/tasks/buildAndUpload/getSaveUploadResultsTask.ts
+++ b/src/tasks/buildAndUpload/getSaveUploadResultsTask.ts
@@ -1,36 +1,34 @@
 import { ListrTask } from "listr/index.js";
 import { addReleaseRecord } from "../../utils/releaseRecord.js";
-import { BuildVariantsMap, ListrContextBuild } from "../../types.js";
+import { PackageToBuildProps, ListrContextBuild } from "../../types.js";
 import { pruneCache } from "../../utils/cache.js";
 import path from "path";
 
 export function getSaveUploadResultsTask({
-  variantsMap,
+  packagesToBuildProps,
   rootDir,
   variantsDirPath,
   contentProvider,
   skipUpload,
-  isMultiVariant
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
   rootDir: string;
   variantsDirPath: string;
   contentProvider: string;
   skipUpload?: boolean;
-  isMultiVariant?: boolean;
 }): ListrTask<ListrContextBuild> {
   return {
     title: "Save upload results",
     skip: () => skipUpload,
     task: async ctx => {
 
-      for (const [variant, { manifest: { name, version } }] of Object.entries(variantsMap)) {
+      for (const { variant, manifest: { name, version } } of packagesToBuildProps) {
         const { releaseMultiHash: hash } = ctx[name];
 
         if (!hash) continue;
 
         addReleaseRecord({
-          dir: isMultiVariant ? path.join(variantsDirPath, variant) : rootDir,
+          dir: variant ? path.join(variantsDirPath, variant) : rootDir,
           version,
           hash,
           to: contentProvider

--- a/src/tasks/buildAndUpload/getUploadTasks.ts
+++ b/src/tasks/buildAndUpload/getUploadTasks.ts
@@ -1,5 +1,5 @@
 import { ListrTask } from "listr/index.js";
-import { BuildVariantsMap, ListrContextBuild } from "../../types.js";
+import { PackageToBuildProps, ListrContextBuild } from "../../types.js";
 import { getGitHeadIfAvailable } from "../../utils/git.js";
 import { getPinMetadata } from "../../pinStrategy/index.js";
 import { PinKeyvaluesDefault } from "../../releaseUploader/pinata/index.js";
@@ -7,13 +7,13 @@ import { IReleaseUploader } from "../../releaseUploader/index.js";
 import { composeDeleteBuildProperties } from "../../files/index.js";
 
 export function getUploadTasks({
-  variantsMap,
+  packagesToBuildProps,
   skipUpload,
   releaseUploader,
   requireGitData,
   composeFileName
 }: {
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
   skipUpload?: boolean;
   releaseUploader: IReleaseUploader;
   requireGitData: boolean;
@@ -21,9 +21,7 @@ export function getUploadTasks({
 }): ListrTask<ListrContextBuild>[] {
   const uploadTasks: ListrTask<ListrContextBuild>[] = [];
 
-  for (const [variant, { manifest, releaseDir }] of Object.entries(
-    variantsMap
-  )) {
+  for (const { manifest, releaseDir } of packagesToBuildProps) {
     const { name: dnpName } = manifest;
 
     uploadTasks.push({
@@ -36,7 +34,8 @@ export function getUploadTasks({
         // https://github.com/dappnode/DAppNode_Installer/issues/161
         composeDeleteBuildProperties({ dir: releaseDir, composeFileName });
 
-        ctx[dnpName] = ctx[dnpName] || { variant };
+        // TODO: Remove this line after cheking that the release is correctly uploaded
+        // ctx[dnpName] = ctx[dnpName] || { variant, releaseDir };
         ctx[dnpName].releaseMultiHash = await releaseUploader.addFromFs({
           dirPath: releaseDir,
           metadata: getPinMetadata(manifest, gitHead) as PinKeyvaluesDefault,

--- a/src/tasks/buildAndUpload/getUploadTasks.ts
+++ b/src/tasks/buildAndUpload/getUploadTasks.ts
@@ -34,8 +34,6 @@ export function getUploadTasks({
         // https://github.com/dappnode/DAppNode_Installer/issues/161
         composeDeleteBuildProperties({ dir: releaseDir, composeFileName });
 
-        // TODO: Remove this line after cheking that the release is correctly uploaded
-        // ctx[dnpName] = ctx[dnpName] || { variant, releaseDir };
         ctx[dnpName].releaseMultiHash = await releaseUploader.addFromFs({
           dirPath: releaseDir,
           metadata: getPinMetadata(manifest, gitHead) as PinKeyvaluesDefault,

--- a/src/tasks/buildAndUpload/index.ts
+++ b/src/tasks/buildAndUpload/index.ts
@@ -27,7 +27,7 @@ export function buildAndUpload({
   composeFileName,
   dir,
   variantsDirPath = defaultVariantsDirName,
-  variantsMap
+  packagesToBuildProps
 }: BuildAndUploadOptions): ListrTask<ListrContextBuild>[] {
   const buildTimeout = parseTimeout(userTimeout);
 
@@ -39,31 +39,31 @@ export function buildAndUpload({
   const releaseUploader = getReleaseUploader(releaseUploaderProvider);
 
   return [
-    getFileValidationTask({ variantsMap, rootDir: dir }),
+    getFileValidationTask({ packagesToBuildProps, rootDir: dir }),
     getVerifyConnectionTask({ releaseUploader, skipUpload }),
-    getReleaseDirCreationTask({ variantsMap }),
+    getReleaseDirCreationTask({ packagesToBuildProps }),
     getFileCopyTask({
-      variantsMap,
+      packagesToBuildProps,
       variantsDirPath,
       rootDir: dir,
       composeFileName,
       requireGitData
     }),
-    ...getBuildTasks({ variantsMap, buildTimeout, skipSave, rootDir: dir }),
+    ...getBuildTasks({ packagesToBuildProps, buildTimeout, skipSave, rootDir: dir }),
     ...getUploadTasks({
-      variantsMap,
+      packagesToBuildProps,
       releaseUploader,
       requireGitData: !!requireGitData,
       composeFileName,
       skipUpload
     }),
     getDeleteOldPinsTask({
-      variantsMap,
+      packagesToBuildProps,
       deleteOldPins: !!deleteOldPins,
       releaseUploaderProvider
     }),
     getSaveUploadResultsTask({
-      variantsMap,
+      packagesToBuildProps,
       rootDir: dir,
       contentProvider,
       variantsDirPath,

--- a/src/tasks/buildAndUpload/types.ts
+++ b/src/tasks/buildAndUpload/types.ts
@@ -1,4 +1,4 @@
-import { BuildVariantsMap, PackageImage } from "../../types.js";
+import { PackageToBuildProps } from "../../types.js";
 import { UploadTo } from "../../releaseUploader/index.js";
 
 export interface BuildAndUploadOptions {
@@ -12,5 +12,5 @@ export interface BuildAndUploadOptions {
   composeFileName: string;
   dir: string;
   variantsDirPath?: string;
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
 }

--- a/src/tasks/generatePublishTxs/index.ts
+++ b/src/tasks/generatePublishTxs/index.ts
@@ -4,7 +4,7 @@ import { getEthereumUrl } from "../../utils/getEthereumUrl.js";
 import { getPublishTxLink } from "../../utils/getLinks.js";
 import { addReleaseTx } from "../../utils/releaseRecord.js";
 import { defaultDir, YargsError } from "../../params.js";
-import { BuildVariantsMap, CliGlobalOptions, ListrContextPublish, TxData } from "../../types.js";
+import { PackageToBuildProps, CliGlobalOptions, ListrContextPublish, TxData } from "../../types.js";
 import { ApmRepository } from "@dappnode/toolkit";
 import registryAbi from "../../contracts/ApmRegistryAbi.json" assert { type: "json" };
 import { semverToArray } from "../../utils/semverToArray.js";
@@ -14,10 +14,6 @@ import { getRegistryAddressFromDnpName } from "./getRegistryAddressFromEns.js";
 import { Repo } from "./types.js";
 
 const isZeroAddress = (address: string): boolean => parseInt(address) === 0;
-
-type GenerateTxVariantsMap = {
-  [K in keyof BuildVariantsMap]: Pick<BuildVariantsMap[K], "manifest">;
-}
 
 /**
  * Generates the transaction data necessary to publish the package.
@@ -35,12 +31,12 @@ export function generatePublishTxs({
   developerAddress,
   ethProvider,
   verbosityOptions,
-  variantsMap
+  packagesToBuildProps,
 }: {
   developerAddress?: string;
   ethProvider: string;
   verbosityOptions: VerbosityOptions;
-  variantsMap: GenerateTxVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
 } & CliGlobalOptions): Listr<ListrContextPublish> {
   // Init APM instance
   const ethereumUrl = getEthereumUrl(ethProvider);
@@ -53,7 +49,7 @@ export function generatePublishTxs({
         task: async (ctx, task) => {
           const contractAddress = "0x0000000000000000000000000000000000000000";
 
-          for (const [, { manifest }] of Object.entries(variantsMap)) {
+          for (const { manifest } of packagesToBuildProps) {
 
             const { name: dnpName, version } = manifest;
             const releaseMultiHash = ctx[dnpName]?.releaseMultiHash;

--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -22,22 +22,20 @@ export function publish({
   githubRelease,
   verbosityOptions,
   variantsDirPath,
-  variantsMap,
-  isMultiVariant
+  packagesToBuildProps,
 }: PublishOptions): ListrTask<ListrContextPublish>[] {
   return [
     getVerifyEthConnectionTask({ ethProvider }),
     getFetchNextVersionsFromApmTask({
       releaseType,
       ethProvider,
-      variantsMap
+      packagesToBuildProps
     }),
     getUpdateFilesTask({
       rootDir: dir,
       variantsDirPath,
       composeFileName,
-      variantsMap,
-      isMultiVariant
+      packagesToBuildProps
     }),
     getBuildAndUploadTask({
       buildOptions: {
@@ -48,7 +46,7 @@ export function publish({
         userTimeout,
         requireGitData,
         deleteOldPins,
-        variantsMap,
+        packagesToBuildProps,
         variantsDirPath
       },
       verbosityOptions
@@ -59,7 +57,7 @@ export function publish({
       developerAddress,
       ethProvider,
       verbosityOptions,
-      variantsMap
+      packagesToBuildProps
     }),
     getCreateGithubReleaseTask({
       dir,

--- a/src/tasks/publish/subtasks/getBuildAndUploadTask.ts
+++ b/src/tasks/publish/subtasks/getBuildAndUploadTask.ts
@@ -1,8 +1,9 @@
 import Listr, { ListrTask } from "listr";
 import { BuildAndUploadOptions } from "../../buildAndUpload/types.js";
-import { ListrContextBuild, ListrContextPublish } from "../../../types.js";
+import { ListrContextPublish } from "../../../types.js";
 import { buildAndUpload } from "../../buildAndUpload/index.js";
 import { VerbosityOptions } from "../../../commands/build/types.js";
+import { merge } from "lodash-es";
 
 export function getBuildAndUploadTask({
   buildOptions,
@@ -21,24 +22,8 @@ export function getBuildAndUploadTask({
 
       const buildResults = await buildTasks.run();
 
-      copyBuildCtxToPublishCtx({
-        buildCtx: buildResults,
-        publishCtx: ctx
-      });
+      // Add build results to publish context
+      ctx = merge(ctx, buildResults);
     }
   };
-}
-
-function copyBuildCtxToPublishCtx({
-  buildCtx,
-  publishCtx
-}: {
-  buildCtx: ListrContextBuild;
-  publishCtx: ListrContextPublish;
-}) {
-  for (const [key, result] of Object.entries(buildCtx)) {
-    publishCtx[key] = publishCtx[key]
-      ? { ...publishCtx[key], ...result }
-      : result;
-  }
 }

--- a/src/tasks/publish/subtasks/getFetchApmVersionsTask.ts
+++ b/src/tasks/publish/subtasks/getFetchApmVersionsTask.ts
@@ -1,22 +1,22 @@
 import { ListrTask } from "listr";
-import { BuildVariantsMap, ListrContextPublish, ReleaseType } from "../../../types.js";
+import { PackageToBuildProps, ListrContextPublish, ReleaseType } from "../../../types.js";
 import { getNextVersionFromApm } from "../../../utils/versions/getNextVersionFromApm.js";
 import { Manifest } from "@dappnode/types";
 
 export function getFetchNextVersionsFromApmTask({
   releaseType,
   ethProvider,
-  variantsMap
+  packagesToBuildProps
 }: {
   releaseType: ReleaseType;
   ethProvider: string;
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
 }): ListrTask<ListrContextPublish> {
   return {
     title: "Fetch current versions from APM",
     task: async ctx => {
 
-      for (const [, { manifest }] of Object.entries(variantsMap)) {
+      for (const { manifest } of packagesToBuildProps) {
         const dnpName = manifest.name;
 
         ctx[dnpName] = ctx[dnpName] || {};

--- a/src/tasks/publish/subtasks/getFetchApmVersionsTask.ts
+++ b/src/tasks/publish/subtasks/getFetchApmVersionsTask.ts
@@ -16,16 +16,20 @@ export function getFetchNextVersionsFromApmTask({
     title: "Fetch current versions from APM",
     task: async ctx => {
 
-      for (const { manifest } of packagesToBuildProps) {
+      for (const { manifest, variant, releaseDir } of packagesToBuildProps) {
         const dnpName = manifest.name;
 
-        ctx[dnpName] = ctx[dnpName] || {};
-        ctx[dnpName].nextVersion = await getNextPackageVersion({
+        const nextVersion = await getNextPackageVersion({
           manifest,
           releaseType,
           ethProvider
         });
 
+        ctx[dnpName] = {
+          variant,
+          releaseDir,
+          nextVersion
+        }
       }
     }
   };

--- a/src/tasks/publish/subtasks/getGenerateTxsTask.ts
+++ b/src/tasks/publish/subtasks/getGenerateTxsTask.ts
@@ -1,6 +1,6 @@
 import { ListrTask } from "listr";
 import { VerbosityOptions } from "../../../commands/build/types.js";
-import { BuildVariantsMap, ListrContextPublish } from "../../../types.js";
+import { PackageToBuildProps, ListrContextPublish } from "../../../types.js";
 import { generatePublishTxs } from "../../generatePublishTxs/index.js";
 
 export function getGenerateTxTask({
@@ -9,14 +9,14 @@ export function getGenerateTxTask({
   developerAddress,
   ethProvider,
   verbosityOptions,
-  variantsMap
+  packagesToBuildProps,
 }: {
   dir: string;
   composeFileName: string;
   developerAddress?: string;
   ethProvider: string;
   verbosityOptions: VerbosityOptions;
-  variantsMap: BuildVariantsMap;
+  packagesToBuildProps: PackageToBuildProps[];
 }): ListrTask<ListrContextPublish> {
   return {
     title: "Generate transaction",
@@ -27,7 +27,7 @@ export function getGenerateTxTask({
         developerAddress,
         ethProvider,
         verbosityOptions,
-        variantsMap
+        packagesToBuildProps,
       });
     }
   };

--- a/src/tasks/publish/subtasks/getUpdateFilesTask.ts
+++ b/src/tasks/publish/subtasks/getUpdateFilesTask.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { ListrTask } from "listr";
-import { BuildVariantsMap, ListrContextPublish } from "../../../types.js";
+import { PackageToBuildProps, ListrContextPublish } from "../../../types.js";
 import {
   writeManifest,
   readCompose,
@@ -14,19 +14,18 @@ export function getUpdateFilesTask({
   rootDir,
   variantsDirPath,
   composeFileName,
-  variantsMap,
-  isMultiVariant
+  packagesToBuildProps,
 }: {
   rootDir: string;
   variantsDirPath: string;
   composeFileName: string;
-  variantsMap: BuildVariantsMap;
-  isMultiVariant: boolean;
+  packagesToBuildProps: PackageToBuildProps[];
 }): ListrTask<ListrContextPublish> {
   return {
     title: "Update compose and manifest files",
     task: async ctx => {
-      for (const [variant, { manifest: { name }, composePaths, manifestPaths }] of Object.entries(variantsMap)) {
+      for (const pkgProps of packagesToBuildProps) {
+        const { variant, manifest: { name }, composePaths, manifestPaths } = pkgProps;
         const nextVersion = ctx[name].nextVersion;
 
         if (!nextVersion) {
@@ -42,16 +41,15 @@ export function getUpdateFilesTask({
           variantsDirPath,
           dnpName: name,
           nextVersion,
-          isMultiVariant
         });
 
         const newCompose = readCompose(composePaths);
         const newManifest = readManifest(manifestPaths).manifest;
 
         // Update variantsMap entry
-        variantsMap[variant].compose = newCompose;
-        variantsMap[variant].manifest = newManifest;
-        variantsMap[variant].images = getComposePackageImages(newCompose, newManifest);
+        pkgProps.compose = newCompose;
+        pkgProps.manifest = newManifest;
+        pkgProps.images = getComposePackageImages(newCompose, newManifest);
       }
     }
   };
@@ -65,19 +63,17 @@ export function updateVariantFiles({
   variantsDirPath,
   dnpName,
   nextVersion,
-  isMultiVariant
 }: {
   rootDir: string;
   composeFileName: string;
-  variant: string;
+  variant: string | null;
   variantsDirPath: string;
   dnpName: string;
   nextVersion: string;
-  isMultiVariant: boolean;
 }): void {
   // For multi-variant packages, manifest and compose files to be modified are located in the variant folder
-  // Single variant packages have single-variant as the variant name
-  const filesDir = isMultiVariant ? path.join(variantsDirPath, variant) : rootDir;
+  // Single variant packages have their files in the root dir
+  const filesDir = variant ? path.join(variantsDirPath, variant) : rootDir;
 
   updateManifestFileVersion({
     manifestDir: filesDir,

--- a/src/tasks/publish/types.ts
+++ b/src/tasks/publish/types.ts
@@ -1,6 +1,6 @@
 import { VerbosityOptions } from "../../commands/build/types.js";
 import { UploadTo } from "../../releaseUploader/index.js";
-import { BuildVariantsMap, ReleaseType } from "../../types.js";
+import { PackageToBuildProps, ReleaseType } from "../../types.js";
 
 export interface PublishOptions {
   releaseType: ReleaseType;
@@ -16,6 +16,5 @@ export interface PublishOptions {
   githubRelease?: boolean;
   verbosityOptions: VerbosityOptions;
   variantsDirPath: string;
-  variantsMap: BuildVariantsMap;
-  isMultiVariant: boolean;
+  packagesToBuildProps: PackageToBuildProps[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,14 +27,14 @@ export interface ListrContextPublish {
   [dnpName: string]: ListrContextPublishItem;
 }
 
-interface PackageToPublishProps {
+export interface PackageToBuildProps {
+  // For packages not following multi-variant format, variant is null
+  // These kind of packages have all their files in the root dir
+  variant: string | null;
+
   // Manifest-related
   manifest: Manifest;
   manifestFormat: ManifestFormat;
-}
-
-export interface PackageToBuildProps extends PackageToPublishProps {
-  variant: string | null;
 
   // Compose file
   compose: Compose;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,9 @@ export interface CliGlobalOptions {
 
 // TODO: Try to have all properties defined
 interface ListrContextBuildItem {
-  releaseDir?: string;
+  variant: string | null;
+  releaseDir: string;
   releaseMultiHash?: string;
-  variant?: string;
 }
 
 interface ListrContextPublishItem extends ListrContextBuildItem {
@@ -27,13 +27,15 @@ export interface ListrContextPublish {
   [dnpName: string]: ListrContextPublishItem;
 }
 
-interface PublishVariantsMapEntry {
+interface PackageToPublishProps {
   // Manifest-related
   manifest: Manifest;
   manifestFormat: ManifestFormat;
 }
 
-export interface BuildVariantsMapEntry extends PublishVariantsMapEntry {
+export interface PackageToBuildProps extends PackageToPublishProps {
+  variant: string | null;
+
   // Compose file
   compose: Compose;
 
@@ -45,10 +47,6 @@ export interface BuildVariantsMapEntry extends PublishVariantsMapEntry {
   // Package information
   images: PackageImage[];
   architectures: Architecture[];
-}
-
-export interface BuildVariantsMap {
-  [variant: string]: BuildVariantsMapEntry;
 }
 
 // Interal types

--- a/test/utils/versions/updateVariantFiles.test.ts
+++ b/test/utils/versions/updateVariantFiles.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import path from "path";
 import { cleanTestDir, testDir } from "../../testUtils.js";
-import { defaultComposeFileName, singleVariantName } from "../../../src/params.js";
+import { defaultComposeFileName } from "../../../src/params.js";
 import {
     writeManifest,
     readCompose,
@@ -34,7 +33,7 @@ describe("Update Variant Files and Entries", function () {
     before("Clean testDir", () => cleanTestDir());
     after("Clean testDir", () => cleanTestDir());
 
-    it("Should update manifest and compose files correctly", async () => {
+    it("Should update manifest and compose files correctly for a single variant package", async () => {
         // Write initial manifest and compose files
         writeManifest(manifest, ManifestFormat.json, { dir: testDir });
         writeCompose(compose, { dir: testDir });
@@ -43,11 +42,10 @@ describe("Update Variant Files and Entries", function () {
         updateVariantFiles({
             rootDir: testDir,
             composeFileName: defaultComposeFileName,
-            variant: singleVariantName,
+            variant: null,
             variantsDirPath: testDir,
             dnpName,
             nextVersion,
-            isMultiVariant: false
         });
 
         // Check that the manifest was updated correctly


### PR DESCRIPTION
This PR overrides https://github.com/dappnode/DAppNodeSDK/pull/440, as code base was out of date.

It aims to move from type:
```javascript

interface BuildVariantsMap {
    [variant: string]: {
      // Compose file
      compose: Compose;
      
      // Manifest-related
      manifest: Manifest;
      manifestFormat: ManifestFormat;
      
      // File paths
      releaseDir: string;
      composePaths: string[];
      
      // Package information
      images: PackageImage[];
      architectures: Architecture[];
   }
}
```

to type:

```javascript
interface PackageToBuildProps {
  variant: string | null;

  // Compose file
  compose: Compose;

  // Manifest-related
  manifest: Manifest;
  manifestFormat: ManifestFormat;

  // File paths
  releaseDir: string;
  composePaths: ComposePaths[];
  manifestPaths: ManifestPaths[];

  // Package information
  images: PackageImage[];
  architectures: Architecture[];
}[]

```