### PR TITLE
Fix AMD build on Mac

### DIFF
--- a/src/tasks/buildAndUpload/getBuildTasks.ts
+++ b/src/tasks/buildAndUpload/getBuildTasks.ts
@@ -5,7 +5,7 @@ import { buildWithBuildx } from "./buildWithBuildx.js";
 import { buildWithCompose } from "./buildWithCompose.js";
 import { Architecture, defaultArch } from "@dappnode/types";
 import { getImageFileName } from "../../utils/getImageFileName.js";
-import { getArchitecture } from "../../utils/getArchitecture.js";
+import { getOsArchitecture } from "../../utils/getArchitecture.js";
 
 /**
  * The naming scheme for multiarch exported images must be
@@ -58,7 +58,7 @@ function createBuildTask({
   const { manifest, releaseDir, images, compose } = variantSpecs;
   const { name, version } = manifest;
   const buildFn =
-    architecture === getArchitecture() ? buildWithCompose : buildWithBuildx;
+    architecture === getOsArchitecture() ? buildWithCompose : buildWithBuildx;
 
   const destPath = getImagePath({
     releaseDir,

--- a/src/tasks/buildAndUpload/getBuildTasks.ts
+++ b/src/tasks/buildAndUpload/getBuildTasks.ts
@@ -5,6 +5,7 @@ import { buildWithBuildx } from "./buildWithBuildx.js";
 import { buildWithCompose } from "./buildWithCompose.js";
 import { Architecture, defaultArch } from "@dappnode/types";
 import { getImageFileName } from "../../utils/getImageFileName.js";
+import { getArchitecture } from "../../utils/getArchitecture.js";
 
 /**
  * The naming scheme for multiarch exported images must be
@@ -57,7 +58,7 @@ function createBuildTask({
   const { manifest, releaseDir, images, compose } = variantSpecs;
   const { name, version } = manifest;
   const buildFn =
-    architecture === defaultArch ? buildWithCompose : buildWithBuildx;
+    architecture === getArchitecture() ? buildWithCompose : buildWithBuildx;
 
   const destPath = getImagePath({
     releaseDir,

--- a/src/utils/getArchitecture.ts
+++ b/src/utils/getArchitecture.ts
@@ -4,14 +4,16 @@ import { Architecture } from "@dappnode/types";
 /**
  * Returns the architecture of the host machine doing the build
  */
-export function getArchitecture(): Architecture {
+export function getOsArchitecture(): Architecture | "unsupported" {
   // Returns the operating system CPU architecture for which the Node.js binary was compiled.
   const arch = os.arch();
 
   // TODO: DAppNode Packages are run in Linux-based systems. This solves the edge case when building in ARM
   if (arch === "arm64") {
     return "linux/arm64";
-  } else {
+  } else if (arch === "x64") {
     return "linux/amd64";
+  } else {
+    return "unsupported";
   }
 }

--- a/src/utils/parseArchitectures.ts
+++ b/src/utils/parseArchitectures.ts
@@ -1,5 +1,4 @@
 import { Architecture, architectures } from "@dappnode/types";
-import { getArchitecture } from "./getArchitecture.js";
 
 /**
  *
@@ -7,7 +6,7 @@ import { getArchitecture } from "./getArchitecture.js";
  * @returns
  */
 export function parseArchitectures({
-  rawArchs = [getArchitecture()]
+  rawArchs = ["linux/amd64"]
 }: {
   rawArchs?: Architecture[];
 }): Architecture[] {


### PR DESCRIPTION
When building multi-arch packages in an ARM device (like latest Macs), the images built would be:
1. `arm64` (variant `v8`)
2. `arm64`

This would happen because native docker build was being used for AMD arch instead of `buildx`