### PR TITLE
Fix git tag generation

### DIFF
--- a/src/tasks/createGithubRelease/buildReleaseDetailsMap.ts
+++ b/src/tasks/createGithubRelease/buildReleaseDetailsMap.ts
@@ -10,7 +10,7 @@ export function buildReleaseDetailsMap(
     dnpName,
     { nextVersion, releaseMultiHash, txData, releaseDir, variant }
   ] of Object.entries(ctx)) {
-    if (!nextVersion || !releaseMultiHash || !txData || !releaseDir || !variant)
+    if (!nextVersion || !releaseMultiHash || !txData || !releaseDir)
       throw new Error(`Missing required release details for ${dnpName}`);
 
     releaseDetailsMap[dnpName] = {

--- a/src/tasks/createGithubRelease/getNextGitTag.ts
+++ b/src/tasks/createGithubRelease/getNextGitTag.ts
@@ -28,9 +28,13 @@ export function getNextGitTag(releaseDetailsMap: GitTagDetailsMap): string {
   // Not a multi-variant package
   if (variantVersions.length === 1) return `v${variantVersions[0].nextVersion}`;
 
+  // If any variant is null, throw an error
+  if (variantVersions.some(({ variant }) => !variant))
+    throw Error("Could not generate git tag. Missing variant");
+
   // Multi-variant package
   return variantVersions
-    .sort((a, b) => a.variant.localeCompare(b.variant)) // Sort alphabetically by variant
+    .sort((a, b) => (a.variant || "").localeCompare(b.variant || "")) // Sort alphabetically by variant
     .map(({ variant, nextVersion }) => `${variant}@${nextVersion}`) // Map to string
     .join("_"); // Join into a single string
 }

--- a/src/tasks/createGithubRelease/types.ts
+++ b/src/tasks/createGithubRelease/types.ts
@@ -6,6 +6,6 @@ export interface ReleaseDetailsMap {
     releaseMultiHash: string;
     txData: TxData;
     releaseDir: string;
-    variant: string;
+    variant: string | null;
   };
 }


### PR DESCRIPTION
SDK publish action in mono-variant package repos would fail with this error:

```
[07:14:41] Release on github [started]
[07:14:41] Handle tags [started]
[07:14:41] Handle tags [failed]
[07:14:41] → Missing required release details for dappmanager.dnp.dappnode.eth
[07:14:41] Release on github [failed]
[07:14:41] → Missing required release details for dappmanager.dnp.dappnode.eth
 ✖ Missing required release details for dappmanager.dnp.dappnode.eth

Error: Missing required release details for dappmanager.dnp.dappnode.eth
    at buildReleaseDetailsMap (file:///home/runner/.npm/_npx/7366de4368e80aba/node_modules/@dappnode/dappnodesdk/src/tasks/createGithubRelease/buildReleaseDetailsMap.ts:14:13)
    at Task.task (file:///home/runner/.npm/_npx/7366de4368e80aba/node_modules/@dappnode/dappnodesdk/src/tasks/createGithubRelease/subtasks/getHandleTagsTask.ts:30:33)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This PR aims to fix this bug by handling the case where `variant` is `null`. This happens when there are no variants for a package repo