### PR TITLE
Use new compose plugin for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/dappnode/DAppNodeSDK#readme",
   "dependencies": {
-    "@dappnode/schemas": "^0.1.20",
+    "@dappnode/schemas": "^0.1.21",
     "@dappnode/toolkit": "^0.1.21",
     "@dappnode/types": "^0.1.39",
     "@octokit/rest": "^20.1.1",

--- a/src/tasks/buildAndUpload/buildWithCompose.ts
+++ b/src/tasks/buildAndUpload/buildWithCompose.ts
@@ -44,7 +44,7 @@ export function buildWithCompose({
       title: "Build docker image",
       task: async (_, task) => {
         // Prior to this task, the compose should had been updated with the proper tag
-        await shell(`docker-compose --file ${tmpComposePath} build`, {
+        await shell(`docker compose --file ${tmpComposePath} build`, {
           timeout: buildTimeout,
           maxBuffer: 100 * 1e6,
           onData: data => (task.output = data)

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@dappnode/schemas@^0.1.20":
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/@dappnode/schemas/-/schemas-0.1.20.tgz#8820e95772d5151d6a6f5561c2a5a151b1debddc"
-  integrity sha512-B44wqcumy84XFaqcP/mu6oySVRZ+Vrdsg3va5zJwdbvmhpHoAnqgvW/DVpP9ofxToOYkyn5iL8fPEO9IrNllPg==
+"@dappnode/schemas@^0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@dappnode/schemas/-/schemas-0.1.21.tgz#6a425767b6fb8e15629d1013d241562fd6d87d1e"
+  integrity sha512-CEuSZfuFzvZw+HE56x+PJtbvg6Z06iF1OzhyyTNMvtzpIO8giir+dtKx8BvgBWc5rYCPTsa3ryhJg8VARC+jnA==
   dependencies:
     "@dappnode/types" "^0.1.38"
     ajv "^8.12.0"


### PR DESCRIPTION
Replace legacy `docker-compose` binary in favour of new `compose` docker plugin for build task