### PR TITLE
Use dappnode's remote ETH provider

### DIFF
--- a/src/commands/publish/handler.ts
+++ b/src/commands/publish/handler.ts
@@ -55,7 +55,7 @@ export async function publishHandler({
       uploadTo = "ipfs";
       verbose = true;
     }
-    ethProvider = "infura";
+    ethProvider = "remote";
     githubRelease = true;
   }
 


### PR DESCRIPTION
internal gh dappnode releases use the "dappnode_team_preset" flag, which uses infura's eth provider. This changes it to use dappnode's